### PR TITLE
Update PR references from /head to /merge

### DIFF
--- a/roles/local_ci/local_ci_run/templates/pod.yaml.j2
+++ b/roles/local_ci/local_ci_run/templates/pod.yaml.j2
@@ -20,7 +20,7 @@ spec:
       git config --global --add safe.directory "$PWD"
 
       if [[ "$PULL_NUMBER" ]]; then
-        git fetch origin refs/pull/$PULL_NUMBER/head:pull_$PULL_NUMBER
+        git fetch origin refs/pull/$PULL_NUMBER/merge:pull_$PULL_NUMBER
         git switch pull_$PULL_NUMBER
         git show --quiet --oneline main..HEAD
       elif [[ "$GIT_REF" ]]; then

--- a/testing/codeflare/command_args.yml.j2
+++ b/testing/codeflare/command_args.yml.j2
@@ -143,5 +143,5 @@ local_ci run_multi/sdk_user:
   sleep_factor: {{ tests.sdk_user.sleep_factor }}
   user_batch_size: {{ tests.sdk_user.user_batch_size }}
 
-  git_pull: null #refs/pull/716/head
+  git_pull: null #refs/pull/716/merge
   capture_prom_db: "{{ tests.capture_prom }}"

--- a/testing/codeflare/prepare_user_pods.py
+++ b/testing/codeflare/prepare_user_pods.py
@@ -23,7 +23,7 @@ def apply_prefer_pr():
         git_ref = os.environ.get("PERFLAB_GIT_REF")
 
         try:
-            pr_number = int(re.compile("refs/pull/([0-9]+)/head").match(git_ref).groups()[0])
+            pr_number = int(re.compile("refs/pull/([0-9]+)/merge").match(git_ref).groups()[0])
         except Exception as e:
             logging.warning("apply_prefer_pr: PERFLAB_CI: base_image.repo.ref_prefer_pr is set cannot parse PERFLAB_GIT_REF={git_erf}: {e.__class__.__name__}: {e}")
             return
@@ -32,7 +32,7 @@ def apply_prefer_pr():
         logging.warning("apply_prefer_pr: Could not figure out the PR number. Keeping the default value.")
         return
 
-    pr_ref = f"refs/pull/{pr_number}/head"
+    pr_ref = f"refs/pull/{pr_number}/merge"
 
     logging.info(f"Setting '{pr_ref}' as ref for building the base image")
     config.ci_artifacts.set_config("base_image.repo.ref", pr_ref)

--- a/testing/common/prepare_user_pods.py
+++ b/testing/common/prepare_user_pods.py
@@ -22,7 +22,7 @@ def apply_prefer_pr():
         git_ref = os.environ.get("PERFLAB_GIT_REF")
 
         try:
-            pr_number = int(re.compile("refs/pull/([0-9]+)/head").match(git_ref).groups()[0])
+            pr_number = int(re.compile("refs/pull/([0-9]+)/merge").match(git_ref).groups()[0])
         except Exception as e:
             logging.warning("apply_prefer_pr: PERFLAB_CI: base_image.repo.ref_prefer_pr is set cannot parse PERFLAB_GIT_REF={git_erf}: {e.__class__.__name__}: {e}")
             return
@@ -37,7 +37,7 @@ def apply_prefer_pr():
         logging.warning("apply_prefer_pr: Could not figure out the PR number. Keeping the default value.")
         return
 
-    pr_ref = f"refs/pull/{pr_number}/head"
+    pr_ref = f"refs/pull/{pr_number}/merge"
 
     logging.info(f"Setting '{pr_ref}' as ref for building the base image")
     config.ci_artifacts.set_config("base_image.repo.ref", pr_ref)

--- a/testing/pipelines/command_args.yml.j2
+++ b/testing/pipelines/command_args.yml.j2
@@ -104,7 +104,7 @@ local_ci run_multi:
   sleep_factor: {{ tests.pipelines.sleep_factor }}
   user_batch_size: {{ tests.pipelines.user_batch_size }}
 
-  git_pull: null #refs/pull/716/head
+  git_pull: null #refs/pull/716/merge
 
 cluster deploy_minio_s3_server:
   namespace: "{{ base_image.namespace }}"

--- a/testing/pipelines/test.py
+++ b/testing/pipelines/test.py
@@ -156,7 +156,7 @@ def apply_prefer_pr():
         git_ref = os.environ.get("PERFLAB_GIT_REF")
 
         try:
-            pr_number = int(re.compile("refs/pull/([0-9]+)/head").match(git_ref).groups()[0])
+            pr_number = int(re.compile("refs/pull/([0-9]+)/merge").match(git_ref).groups()[0])
         except Exception as e:
             logging.warning("apply_prefer_pr: PERFLAB_CI: base_image.repo.ref_prefer_pr is set cannot parse PERFLAB_GIT_REF={git_erf}: {e.__class__.__name__}: {e}")
             return
@@ -165,7 +165,7 @@ def apply_prefer_pr():
         logging.warning("apply_prefer_pr: Could not figure out the PR number. Keeping the default value.")
         return
 
-    pr_ref = f"refs/pull/{pr_number}/head"
+    pr_ref = f"refs/pull/{pr_number}/merge"
 
     logging.info(f"Setting '{pr_ref}' as ref for building the base image")
     config.ci_artifacts.set_config("base_image.repo.ref", pr_ref)

--- a/testing/watsonx-serving/command_args.yml.j2
+++ b/testing/watsonx-serving/command_args.yml.j2
@@ -133,7 +133,7 @@ local_ci run_multi/scale:
   sleep_factor: {{ tests.scale.sleep_factor }}
   user_batch_size: {{ tests.scale.user_batch_size }}
 
-  git_pull: null #refs/pull/716/head
+  git_pull: null #refs/pull/716/merge
   capture_prom_db: "{{ tests.capture_prom }}"
 
 #


### PR DESCRIPTION
so that we get the merged commit, not the branch `HEAD`. This could lead to failures when the PR is not rebased.