### PR TITLE
Watsonx: test mbt & flan memory profiles

### DIFF
--- a/testing/watsonx-serving/config.yaml
+++ b/testing/watsonx-serving/config.yaml
@@ -23,7 +23,7 @@ ci_presets:
   quick:
     gpu.prepare_cluster: false
     clusters.sutest.compute.machineset.type: m6i.2xlarge
-    tests.e2e.models: [flan-t5-small-cpu]
+    tests.e2e.models: [flan-t5-small-cpu, flan-t5-small-cpu]
 
   metal:
     clusters.sutest.is_metal: true

--- a/visualizations/watsonx-serving-scale/plotting/prom_report.py
+++ b/visualizations/watsonx-serving-scale/plotting/prom_report.py
@@ -55,10 +55,6 @@ class SutestCpuMemoryReport():
 
         header += [html.P("These plots show an overview of the CPU and Memory usage during the execution of the test, for the cluster, the nodes, and various relevant Pods.")]
 
-        header += [html.H2("SUTest Cluster")]
-        header += [report.Plot("Prom: sutest cluster memory usage", args)]
-        header += [report.Plot("Prom: sutest cluster CPU usage", args)]
-
         header += ["These plots show the CPU and memory capacity of the SUTest cluster."]
         header += html.Br()
         header += html.Br()
@@ -69,6 +65,10 @@ class SutestCpuMemoryReport():
             header += [report.Plot(f"Prom: {plot_name}: CPU usage", args)]
             header += [report.Plot(f"Prom: {plot_name}: Mem usage", args)]
 
+
+        header += [html.H2("SUTest Cluster")]
+        header += [report.Plot("Prom: sutest cluster memory usage", args)]
+        header += [report.Plot("Prom: sutest cluster CPU usage", args)]
 
         return None, header
 

--- a/visualizations/watsonx-serving-scale/store/prom.py
+++ b/visualizations/watsonx-serving-scale/store/prom.py
@@ -46,6 +46,7 @@ def _get_container_mem(cluster_role, labels):
         {f"{cluster_role}__container_memory__{metric_name}": "container_memory_rss{"+labels_str+"}"},
         {f"{cluster_role}__container_memory_requests__{metric_name}": "kube_pod_container_resource_requests{"+labels_str+",resource='memory'}"},
         {f"{cluster_role}__container_memory_limits__{metric_name}": "kube_pod_container_resource_limits{"+labels_str+",resource='memory'}"},
+        {f"{cluster_role}__container_max_memory__{metric_name}": "container_memory_max_usage_bytes{"+labels_str+"}"},
     ]
 
 def _get_container_cpu_mem(labelss):


### PR DESCRIPTION
```
   e2e_perf_flan:
     extends: [e2e_perf]
     tests.e2e.llm_load_test.duration: 10m
     watsonx_serving.model.serving_runtime.mute_logs: false # secret key has been disabled
     tests.e2e.models:
     - flan-t5-small-gpu-2gb:
         name: flan-t5-small-gpu
         serving_runtime:
           resource_request:
             memory: 2 # in Gi
     - flan-t5-small-gpu-3gb:
         name: flan-t5-small-gpu
         serving_runtime:
           resource_request:
             memory: 3 # in Gi
     - flan-t5-small-gpu-4gb:
         name: flan-t5-small-gpu
         serving_runtime:
           resource_request:
             memory: 4 # in Gi
     - flan-t5-small-gpu-5gb:
         name: flan-t5-small-gpu
         serving_runtime:
           resource_request:
             memory: 5 # in Gi
```
```
  e2e_perf_mbt:
    extends: [e2e_perf_strict_limits]
    tests.e2e.llm_load_test.duration: 1m
    tests.e2e.models:
    - mpt-7b-instruct2-8gb:
        name: mpt-7b-instruct2
        serving_runtime:
          resource_request:
            memory: 8 # in Gi
    - mpt-7b-instruct2-7gb:
        name: mpt-7b-instruct2
        serving_runtime:
          resource_request:
            memory: 7 # in Gi
    - mpt-7b-instruct2-6gb:
        name: mpt-7b-instruct2
        serving_runtime:
          resource_request:
            memory: 6 # in Gi
    - mpt-7b-instruct2-5gb:
        name: mpt-7b-instruct2
        serving_runtime:
          resource_request:
            memory: 5 # in Gi
```