### PR TITLE
testing: watsonx-serving: config: spot_cluster: move to us-east-2 region

### DIFF
--- a/testing/watsonx-serving/config.yaml
+++ b/testing/watsonx-serving/config.yaml
@@ -47,6 +47,7 @@ ci_presets:
   spot_cluster:
     extends: [spot_compute]
     clusters.create.ocp.workers.spot: true
+    clusters.create.ocp.region: us-east-2
 
   # ---
 


### PR DESCRIPTION
To see if spot is easier to use in bigger regions