### PR TITLE
Remove hardwired roles inclusion

### DIFF
--- a/config/ansible.cfg
+++ b/config/ansible.cfg
@@ -13,8 +13,11 @@ retry_files_enabled = False
 retry_files_save_path = /tmp/ansible-installer-retries
 nocows = True
 remote_user = root
-# cd roles; echo ../roles/* | tr " " :
-roles_path = ../roles/benchmarking:../roles/cluster:../roles/codeflare:../roles/entitlement:../roles/gpu_operator:../roles/load_aware:../roles/local_ci:../roles/nfd:../roles/ocm:../roles/pipelines:../roles/rhods:../roles/utils:../roles/wisdom:../roles/watsonx_serving:../roles/llm_load_test:../roles/notebooks
+
+# Both roles_path and collections_paths are configured
+# dynamically in the_common.py library, this is to avoid
+# removing the default paths from the ansible interpreter.
+
 gathering = smart
 callbacks_enabled = json_to_logfile, timer, profile_roles
 inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt, .ini


### PR DESCRIPTION
This commit allows to dinamically include
all the roles in the repository so the Ansible
interpreter can find them independently of
how many roles are in the repository.