### PR TITLE
rhods_update_datasciencecluster: use `oc delete/create` instead of `oc replace`

### DIFF
--- a/roles/rhods/rhods_update_datasciencecluster/tasks/main.yml
+++ b/roles/rhods/rhods_update_datasciencecluster/tasks/main.yml
@@ -84,7 +84,8 @@
 - name: Create the DataScienceCluster
   shell: |
     set -e
-    oc replace -f "{{ artifact_extra_logs_dir }}/src/datascience_cluster.yaml"
+    oc delete -f "{{ artifact_extra_logs_dir }}/src/datascience_cluster.yaml"
+    oc create -f "{{ artifact_extra_logs_dir }}/src/datascience_cluster.yaml"
 
 - name: Wait for the DataScienceCluster to be ready and capture artifacts
   block:


### PR DESCRIPTION
`oc replace` can fail with:
```
<stderr>
Error from server (Conflict): error when replacing
"/logs/artifacts/013__sutest_rhods__update_datasciencecluster/src/datascience_cluster.yaml":
Operation cannot be fulfilled on
datascienceclusters.datasciencecluster.opendatahub.io "default-dsc":
the object has been modified; please apply your changes to the latest
version and try again
```