### PR TITLE
Minor ci-artifacts -> topsail rename cleanup

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,4 +1,4 @@
-title = "ci-artifacts gitleaks config"
+title = "topsail gitleaks config"
 
 [allowlist]
   paths = [

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ available commands.
 
 The functionalities of the toolbox commands are described in the
 `🚧 under construction 🚧 documentation page
-<https://openshift-psap.github.io/ci-artifacts/index.html#psap-toolbox>`_.
+<https://openshift-psap.github.io/topsail/index.html#psap-toolbox>`_.
 
 
 .. |lint| image:: https://github.com/openshift-psap/topsail/actions/workflows/ansible-lint.yml/badge.svg?event=schedule

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,10 +2,10 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 MAINTAINER OpenShift PSAP Team <openshift-psap@redhat.com>
 
-LABEL 	io.k8s.display-name="OpenShift PSAP CI artifacts" \
+LABEL 	io.k8s.display-name="OpenShift PSAP topsail" \
       	io.k8s.description="An image for running Ansible artifacts for OpenShift PSAP CI" \
- 	name="ci-artifacts" \
-	url="https://github.com/openshift-psap/ci-artifacts"
+ 	name="topsail" \
+	url="https://github.com/openshift-psap/"
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -41,7 +41,7 @@ RUN wget --quiet "https://github.com/prometheus/prometheus/releases/download/v${
 # Set up the runner user
 ENV USER_NAME=psap-ci-runner \
     USER=psap-ci-runner \
-    HOME=/opt/ci-artifacts/src \
+    HOME=/opt/topsail/src \
     INSIDE_CI_IMAGE="y"
 ENV ANSIBLE_CONFIG="${HOME}/config/ansible.cfg"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Red Hat PSAP CI-Artifacts toolbox'
+project = 'Red Hat PSAP topsail toolbox'
 copyright = '2021, Red Hat PSAP team'
 author = 'Red Hat PSAP team'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 =================================
-Red Hat PSAP CI-Artifacts toolbox
+Red Hat PSAP TOPSAIL toolbox
 =================================
 
 .. toctree::

--- a/testing/run
+++ b/testing/run
@@ -101,8 +101,8 @@ prechecks() {
     # avoid incorrect error reporting (mostly for outside of CI)
     rm -f "${ARTIFACT_DIR}/FAILURE"
 
-    # store `ci-artifacts` version in use
-    (git describe HEAD --long --always || echo "git missing") > ${ARTIFACT_DIR}/ci_artifact.git_version
+    # store `topsail` version in use
+    (git describe HEAD --long --always || echo "git missing") > ${ARTIFACT_DIR}/topsail.git_version
 
     if [[ "${PULL_NUMBER:-}" ]]; then
         PR_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls/$PULL_NUMBER"


### PR DESCRIPTION
I found a few places where ci-artifacts should be replaced with topsail, that should have no impact on functionality.