### PR TITLE
[skeleton] visualizations: skeleton: validate the LTS payload after generating it

### DIFF
--- a/projects/skeleton/visualizations/skeleton/store/lts.py
+++ b/projects/skeleton/visualizations/skeleton/store/lts.py
@@ -43,6 +43,8 @@ def build_lts_payloads():
         results = entry.results
         lts_payload = results.lts
 
+        validate_lts_payload(lts_payload, entry.import_settings, reraise=True)
+
         yield lts_payload, lts_payload.metadata.start, lts_payload.metadata.end
 
 


### PR DESCRIPTION

when called from `matbench parse --output-lts`