### PR TITLE
Revert "[kserve] testing: config: update to RHOAI 2.6-pre-rc"

### DIFF
--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -269,10 +269,10 @@ clusters:
 rhods:
   catalog:
     image: brew.registry.redhat.io/rh-osbs/iib
-    tag: 649886
-    channel: stable
-    version: 2.6.0
-    version_name: pre-RC
+    tag: 636599
+    channel: alpha
+    version: 2.5.0
+    version_name: RC5
   operator:
     # set to true to stop the RHODS operator
     stop: false


### PR DESCRIPTION
This reverts commit e9ac94dda72eb4fa518587ad88e1071ab316fd75.

Merged by mistake