### PR TITLE
Add Regression Indicators

### DIFF
--- a/projects/notebooks/testing/generate_matrix-benchmarking.sh
+++ b/projects/notebooks/testing/generate_matrix-benchmarking.sh
@@ -5,8 +5,8 @@ set -o pipefail
 set -o nounset
 set -x
 
-TESTING_NOTEBOOKS_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
-TOPSAIL_DIR="$(cd "$TESTING_NOTEBOOKS_DIR/../../.." >/dev/null 2>&1 && pwd )"
+TESTING_NOTEBOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+TOPSAIL_DIR="$(cd "$TESTING_NOTEBOOKS_DIR/../../.." >/dev/null 2>&1 && pwd)"
 TESTING_UTILS_DIR="$TOPSAIL_DIR/testing/utils"
 
 source "$TESTING_NOTEBOOKS_DIR/configure.sh"
@@ -21,309 +21,310 @@ export MATBENCH_WORKLOAD=projects.notebooks.visualizations.$(get_config matbench
 WORKLOAD_STORAGE_DIR="$(echo "$MATBENCH_WORKLOAD" | tr . /)"
 
 if [[ "${JOB_NAME_SAFE:-}" == "plot" ]]; then
-    set_config_from_pr_arg 1 "matbench.preset"
+	set_config_from_pr_arg 1 "matbench.preset"
 fi
 
 matbench_preset=$(get_config matbench.preset)
 
 if [[ "$matbench_preset" == null ]]; then
-    # no preset defined
-    true
+	# no preset defined
+	true
 
 elif [[ "$matbench_preset" == "https://"* ]]; then
-    set_config matbench.download.url "$matbench_preset"
+	set_config matbench.download.url "$matbench_preset"
 else
-    set_config matbench.config_file "${matbench_preset}.yaml"
-    set_config matbench.download.url_file "${WORKLOAD_STORAGE_DIR}/data/${matbench_preset}.yaml"
+	set_config matbench.config_file "${matbench_preset}.yaml"
+	set_config matbench.download.url_file "${WORKLOAD_STORAGE_DIR}/data/${matbench_preset}.yaml"
 fi
 
 get_matbench_config() {
-    CI_ARTIFACTS_FROM_CONFIG_FILE=$WORKLOAD_STORAGE_DIR/data/$(get_config matbench.config_file) \
-        get_config "$@"
+	CI_ARTIFACTS_FROM_CONFIG_FILE=$WORKLOAD_STORAGE_DIR/data/$(get_config matbench.config_file) \
+		get_config "$@"
 }
 
-
 generate_matbench::prepare_matrix_benchmarking() {
-    pip install --quiet --requirement "subprojects/matrix-benchmarking/requirements.txt"
-    pip install --quiet --requirement "$WORKLOAD_STORAGE_DIR/requirements.txt"
+	pip install --quiet --requirement "subprojects/matrix-benchmarking/requirements.txt"
+	pip install --quiet --requirement "$WORKLOAD_STORAGE_DIR/requirements.txt"
 }
 
 _get_data_from_pr() {
-    if [[ -z "$MATBENCH_RESULTS_DIRNAME" ]]; then
-        echo "ERROR: _get_data_from_pr expects MATBENCH_RESULTS_DIRNAME to be set ..."
-    fi
+	if [[ -z "$MATBENCH_RESULTS_DIRNAME" ]]; then
+		echo "ERROR: _get_data_from_pr expects MATBENCH_RESULTS_DIRNAME to be set ..."
+	fi
 
-    MATBENCH_URL=$(get_config matbench.download.url)
-    MATBENCH_URL_FILE=$(get_config matbench.download.url_file)
+	MATBENCH_URL=$(get_config matbench.download.url)
+	MATBENCH_URL_FILE=$(get_config matbench.download.url_file)
 
-    if [[ "$MATBENCH_URL" != null ]]; then
-        export MATBENCH_URL
+	if [[ "$MATBENCH_URL" != null ]]; then
+		export MATBENCH_URL
 
-        echo "$MATBENCH_URL" > "$ARTIFACT_DIR/source_url"
-    elif [[ "$MATBENCH_URL_FILE" != null ]]; then
-        export MATBENCH_URL_FILE
+		echo "$MATBENCH_URL" >"$ARTIFACT_DIR/source_url"
+	elif [[ "$MATBENCH_URL_FILE" != null ]]; then
+		export MATBENCH_URL_FILE
 
-        cp "$MATBENCH_URL_FILE" "$ARTIFACT_DIR/source_url"
-    else
-        _error "matbench.download.url or matbench.download.url_file must be specified"
-    fi
-    export MATBENCH_MODE=$(get_config matbench.download.mode)
+		cp "$MATBENCH_URL_FILE" "$ARTIFACT_DIR/source_url"
+	else
+		_error "matbench.download.url or matbench.download.url_file must be specified"
+	fi
+	export MATBENCH_MODE=$(get_config matbench.download.mode)
 
-    matbench download --do-download |& tee > "$ARTIFACT_DIR/_matbench_download.log"
+	matbench download --do-download |& tee >"$ARTIFACT_DIR/_matbench_download.log"
 }
 
 generate_matbench::get_prometheus() {
-    export PATH=$PATH:/tmp/bin
-    if which prometheus 2>/dev/null; then
-       echo "Prometheus already available."
-       return
-    fi
-    PROMETHEUS_VERSION=2.36.0
-    cd /tmp
-    wget --quiet "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz" -O/tmp/prometheus.tar.gz
-    tar xf "/tmp/prometheus.tar.gz" -C /tmp
-    mkdir -p /tmp/bin
-    ln -sf "/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/prometheus" /tmp/bin
-    cp "/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/prometheus.yml" /tmp/
+	export PATH=$PATH:/tmp/bin
+	if which prometheus 2>/dev/null; then
+		echo "Prometheus already available."
+		return
+	fi
+	PROMETHEUS_VERSION=2.36.0
+	cd /tmp
+	wget --quiet "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz" -O/tmp/prometheus.tar.gz
+	tar xf "/tmp/prometheus.tar.gz" -C /tmp
+	mkdir -p /tmp/bin
+	ln -sf "/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/prometheus" /tmp/bin
+	cp "/tmp/prometheus-${PROMETHEUS_VERSION}.linux-amd64/prometheus.yml" /tmp/
 }
-
 
 generate_matbench::generate_visualizations() {
-    if [[ -z "${MATBENCH_RESULTS_DIRNAME:-}" ]]; then
-        _error " expected MATBENCH_RESULTS_DIRNAME to be set ..."
-        exit 1 # shouldn't be reached
-    fi
+	if [[ -z "${MATBENCH_RESULTS_DIRNAME:-}" ]]; then
+		_error " expected MATBENCH_RESULTS_DIRNAME to be set ..."
+		exit 1 # shouldn't be reached
+	fi
 
-    length=$(get_matbench_config visualize | jq '. | length')
-    plotting_failed=0
-    for idx in $(seq 0 $((length - 1))); do
-        if ! generate_matbench::generate_visualization "$idx"; then
-            plotting_failed=1 # do not fail before the end of the visualization generation
-        fi
-    done
+	length=$(get_matbench_config visualize | jq '. | length')
+	plotting_failed=0
+	for idx in $(seq 0 $((length - 1))); do
+		if ! generate_matbench::generate_visualization "$idx"; then
+			plotting_failed=1 # do not fail before the end of the visualization generation
+		fi
+	done
 
-    return $plotting_failed
+	return $plotting_failed
 }
 
-
 generate_matbench::generate_visualization() {
-    local idx=$1
+	local idx=$1
 
-    if [[ "$(get_matbench_config visualize[$idx].generate)" == null ]]; then
-        _warning "Could not find the list of plots to generate in $MATBENCH_RESULTS_DIRNAME visualization #$idx ..."
-        return
-    fi
+	if [[ "$(get_matbench_config visualize[$idx].generate)" == null ]]; then
+		_warning "Could not find the list of plots to generate in $MATBENCH_RESULTS_DIRNAME visualization #$idx ..."
+		return
+	fi
 
-    generate_list=$(get_matbench_config visualize[$idx].generate[])
+	generate_list=$(get_matbench_config visualize[$idx].generate[])
 
-    filters=$(get_matbench_config visualize[$idx].filters)
-    if [[ "$filters" != null ]]; then
-        filters="$(get_matbench_config visualize[$idx].filters[])"
-    else
-        filters="null"
-    fi
+	filters=$(get_matbench_config visualize[$idx].filters)
+	if [[ "$filters" != null ]]; then
+		filters="$(get_matbench_config visualize[$idx].filters[])"
+	else
+		filters="null"
+	fi
 
-    export MATBENCH_RHODS_NOTEBOOKS_UX_CONFIG=$(get_config matbench.config_file)
-    export MATBENCH_RHODS_NOTEBOOKS_UX_CONFIG_ID=$(get_matbench_config visualize[$idx].id)
+	export MATBENCH_RHODS_NOTEBOOKS_UX_CONFIG=$(get_config matbench.config_file)
+	export MATBENCH_RHODS_NOTEBOOKS_UX_CONFIG_ID=$(get_matbench_config visualize[$idx].id)
 
-    generate_url="stats=$(echo -n "$generate_list" | tr '\n' '&' | sed 's/&/&stats=/g')"
+	generate_url="stats=$(echo -n "$generate_list" | tr '\n' '&' | sed 's/&/&stats=/g')"
 
-    #
-    # Parse
-    #
+	#
+	# Parse
+	#
 
-    step_idx=0
-    if ! matbench parse --output-matrix $ARTIFACT_DIR/internal_matrix.json |& tee > "$ARTIFACT_DIR/${step_idx}_matbench_parse.log"; then
-        _warning "An error happened during the parsing of the results (or no results were available) in $MATBENCH_RESULTS_DIRNAME, aborting."
-        return 1
-    fi
+	step_idx=0
+	if ! matbench parse --output-matrix $ARTIFACT_DIR/internal_matrix.json |& tee >"$ARTIFACT_DIR/${step_idx}_matbench_parse.log"; then
+		_warning "An error happened during the parsing of the results (or no results were available) in $MATBENCH_RESULTS_DIRNAME, aborting."
+		return 1
+	fi
 
-    #
-    # Generate LTS
-    #
+	#
+	# Generate LTS
+	#
 
-    step_idx=$((step_idx + 1))
-    retcode=0
-    if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee > "$ARTIFACT_DIR/${step_idx}_matbench_generate_lts.log"; then
-        _warning "An error happened while generating the LTS payload from $MATBENCH_RESULTS_DIRNAME :/."
-        retcode=1
-    fi
+	step_idx=$((step_idx + 1))
+	retcode=0
+	if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee >"$ARTIFACT_DIR/${step_idx}_matbench_generate_lts.log"; then
+		_warning "An error happened while generating the LTS payload from $MATBENCH_RESULTS_DIRNAME :/."
+		retcode=1
+	fi
 
-    #
-    # Generate LTS schema
-    #
+	#
+	# Generate LTS schema
+	#
 
-    step_idx=$((step_idx + 1))
-    if ! matbench generate_lts_schema --file $ARTIFACT_DIR/lts_payload.schema.json |& tee > "$ARTIFACT_DIR/${step_idx}_matbench_generate_lts_schema.log"; then
-        _warning "An error happened while generating the LTS Notebook JSON Schema :/"
-        retcode=1
-    fi
+	step_idx=$((step_idx + 1))
+	if ! matbench generate_lts_schema --file $ARTIFACT_DIR/lts_payload.schema.json |& tee >"$ARTIFACT_DIR/${step_idx}_matbench_generate_lts_schema.log"; then
+		_warning "An error happened while generating the LTS Notebook JSON Schema :/"
+		retcode=1
+	fi
 
-    generate_opensearch_config() {
-        instance=$(get_config matbench.lts.opensearch.instance)
-        index_prefix=$(get_config matbench.lts.opensearch.index_prefix)
-        index=$(get_config matbench.lts.opensearch.index)
+	generate_opensearch_config() {
+		instance=$(get_config matbench.lts.opensearch.instance)
+		index_prefix=$(get_config matbench.lts.opensearch.index_prefix)
+		index=$(get_config matbench.lts.opensearch.index)
 
-        if [[ "$index_prefix" == null ]]; then
-            index_prefix=""
-        fi
+		if [[ "$index_prefix" == null ]]; then
+			index_prefix=""
+		fi
 
-        vault_key=$(get_config secrets.dir.env_key)
-        opensearch_instances_file=$(get_config secrets.opensearch_instances)
+		vault_key=$(get_config secrets.dir.env_key)
+		opensearch_instances_file=$(get_config secrets.opensearch_instances)
 
-        secret_file="${!vault_key}/${opensearch_instances_file}"
-        if ! [[ -f "$secret_file" ]]; then
-            _error "File '$secret_file' not found in the vault. Skipping regression analyzes."
-            return
-        fi
+		secret_file="${!vault_key}/${opensearch_instances_file}"
+		if ! [[ -f "$secret_file" ]]; then
+			_error "File '$secret_file' not found in the vault. Skipping regression analyzes."
+			return
+		fi
 
-        yq '{
+		yq '{
                   "opensearch_username": .'$instance'.username,
                   "opensearch_password": .'$instance'.password,
                   "opensearch_port": .'$instance'.port,
                   "opensearch_host": .'$instance'.host,
                   "opensearch_index": "'$index_prefix$index'",
-        }' "$secret_file" > .env.generated.yaml
-    }
+        }' "$secret_file" >.env.generated.yaml
+	}
 
-    #
-    # Download the LTS results
-    # Analyze the current results against LTS results
-    #
+	#
+	# Download the LTS results
+	# Analyze the current results against LTS results
+	#
 
-    if test_config matbench.lts.regression_analyses.enabled; then
-        generate_opensearch_config
+	if test_config matbench.lts.regression_analyses.enabled; then
+		generate_opensearch_config
 
-        step_idx=$((step_idx + 1))
+		step_idx=$((step_idx + 1))
 
-        if ! matbench download_lts --lts_results_dirname "$MATBENCH_RESULTS_DIRNAME/lts" \
-           |& tee > "$ARTIFACT_DIR/${step_idx}_matbench_download_lts.log";
-        then
-            _warning "An error happened while downloading the LTS results :/."
-            retcode=1
-        fi
+		if ! matbench download_lts --lts_results_dirname "$MATBENCH_RESULTS_DIRNAME/lts" |&
+			tee >"$ARTIFACT_DIR/${step_idx}_matbench_download_lts.log"; then
+			_warning "An error happened while downloading the LTS results :/."
+			retcode=1
+		fi
 
-        step_idx=$((step_idx + 1))
-        regression_analyses_retcode=0
-        matbench analyze-lts --lts_results_dirname "$MATBENCH_RESULTS_DIRNAME/lts" \
-            |& tee > "$ARTIFACT_DIR/${step_idx}_matbench_analyze_lts.log" \
-            || regression_analyses_retcode=$?
+		step_idx=$((step_idx + 1))
+		regression_analyses_retcode=0
+		matbench analyze-lts --lts_results_dirname "$MATBENCH_RESULTS_DIRNAME/lts" |&
+			tee >"$ARTIFACT_DIR/${step_idx}_matbench_analyze_lts.log" ||
+			regression_analyses_retcode=$?
 
-        if [[ $regression_analyses_retcode == 0 ]]; then
-            _info "The regression analyses did not hit any issue."
-        else
-            if [[ $regression_analyses_retcode < 100 ]]; then
-                _warning "The regression analyses detected a regression :|"
-            else
-                _warning "An error code #$regression_analyses_retcode happened during the regression analyses :/"
-            fi
+		if [[ $regression_analyses_retcode == 0 ]]; then
+			_info "The regression analyses did not hit any issue."
+		else
+			if [[ $regression_analyses_retcode < 100 ]]; then
+				_warning "The regression analyses detected a regression :|"
+			else
+				_warning "An error code #$regression_analyses_retcode happened during the regression analyses :/"
+			fi
 
-            if test_config matbench.lts.regression_analyses.fail_test_on_regression_fail;
-            then
-                retcode=1
-            else
-                _info "An error code #$regression_analyses_retcode happened during the regression analyses, but the 'fail_test_on_regression_fail' flag is not set. Ignoring."
-            fi
-        fi
+			if test_config matbench.lts.regression_analyses.fail_test_on_regression_fail; then
+				retcode=1
+			else
+				_info "An error code #$regression_analyses_retcode happened during the regression analyses, but the 'fail_test_on_regression_fail' flag is not set. Ignoring."
+			fi
+		fi
 
-        rm -f .env.yaml
-    fi
+		rm -f .env.yaml
+		step_idx=$((step_idx + 1))
+		retcode=0
+		if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee >"$ARTIFACT_DIR/${step_idx}_matbench_generate_lts.log"; then
+			_warning "An error happened while generating the LTS payload from $MATBENCH_RESULTS_DIRNAME :/."
+			retcode=1
+		fi
+	fi
 
-    #
-    # Upload LTS results
-    #
+	#
+	# Upload LTS results
+	#
 
-    if test_config matbench.lts.opensearch.upload; then
-        generate_opensearch_config
+	if test_config matbench.lts.opensearch.upload; then
+		generate_opensearch_config
 
-        step_idx=$((step_idx + 1))
-        if ! matbench upload_lts |& tee > "$ARTIFACT_DIR/${step_idx}_matbench_upload_lts.log"; then
-            _warning "An error happened while uploading the LTS payload :/"
-            if test_config matbench.lts.opensearch.fail_test_on_upload_fail; then
-                retcode=1
-            fi
-        fi
-        rm -f .env.yaml
-    fi
+		step_idx=$((step_idx + 1))
+		if ! matbench upload_lts |& tee >"$ARTIFACT_DIR/${step_idx}_matbench_upload_lts.log"; then
+			_warning "An error happened while uploading the LTS payload :/"
+			if test_config matbench.lts.opensearch.fail_test_on_upload_fail; then
+				retcode=1
+			fi
+		fi
+		rm -f .env.yaml
+	fi
 
-    if test_config matbench.download.save_to_artifacts; then
-        cp -rv "$MATBENCH_RESULTS_DIRNAME" "$ARTIFACT_DIR"
-    fi
+	if test_config matbench.download.save_to_artifacts; then
+		cp -rv "$MATBENCH_RESULTS_DIRNAME" "$ARTIFACT_DIR"
+	fi
 
-    #
-    # Generate the visualization reports
-    #
+	#
+	# Generate the visualization reports
+	#
 
-    for filters_to_apply in $filters; do
-        if [[ "$filters_to_apply" == "null" ]]; then
-            filters_to_apply=""
-        fi
+	for filters_to_apply in $filters; do
+		if [[ "$filters_to_apply" == "null" ]]; then
+			filters_to_apply=""
+		fi
 
-        mkdir -p "$ARTIFACT_DIR/$filters_to_apply"
-        cd "$ARTIFACT_DIR/$filters_to_apply"
+		mkdir -p "$ARTIFACT_DIR/$filters_to_apply"
+		cd "$ARTIFACT_DIR/$filters_to_apply"
 
-        step_idx=$((step_idx + 1))
-        VISU_LOG_FILE="$ARTIFACT_DIR/$filters_to_apply/${step_idx}_matbench_visualize.log"
+		step_idx=$((step_idx + 1))
+		VISU_LOG_FILE="$ARTIFACT_DIR/$filters_to_apply/${step_idx}_matbench_visualize.log"
 
-        export MATBENCH_FILTERS="$filters_to_apply"
-        if [[ -d "$MATBENCH_RESULTS_DIRNAME/lts" ]]; then
-            LTS_DIR="--lts_results_dirname $MATBENCH_RESULTS_DIRNAME/lts"
-        else
-            LTS_DIR=""
-        fi
-        if ! matbench visualize --generate="$generate_url" $LTS_DIR |& tee > "$VISU_LOG_FILE"; then
-            _warning "Visualization generation failed :("
-            retcode=1
-        fi
-        if grep "^ERROR" "$VISU_LOG_FILE"; then
-            _warning "An error happened during the report generation :/."
-            grep "^ERROR" "$VISU_LOG_FILE" >> "$ARTIFACT_DIR"/FAILURE
-            retcode=1
-        fi
-        unset MATBENCH_FILTERS
+		export MATBENCH_FILTERS="$filters_to_apply"
+		if [[ -d "$MATBENCH_RESULTS_DIRNAME/lts" ]]; then
+			LTS_DIR="--lts_results_dirname $MATBENCH_RESULTS_DIRNAME/lts"
+		else
+			LTS_DIR=""
+		fi
+		if ! matbench visualize --generate="$generate_url" $LTS_DIR |& tee >"$VISU_LOG_FILE"; then
+			_warning "Visualization generation failed :("
+			retcode=1
+		fi
+		if grep "^ERROR" "$VISU_LOG_FILE"; then
+			_warning "An error happened during the report generation :/."
+			grep "^ERROR" "$VISU_LOG_FILE" >>"$ARTIFACT_DIR"/FAILURE
+			retcode=1
+		fi
+		unset MATBENCH_FILTERS
 
-        mkdir -p figures_{png,html}
-        mv fig_*.png "figures_png" 2>/dev/null || true
-        mv fig_*.html "figures_html" 2>/dev/null || true
-    done
+		mkdir -p figures_{png,html}
+		mv fig_*.png "figures_png" 2>/dev/null || true
+		mv fig_*.html "figures_html" 2>/dev/null || true
+	done
 
-    cd "$ARTIFACT_DIR"
-    return $retcode
+	cd "$ARTIFACT_DIR"
+	return $retcode
 }
 
 action=${1:-}
 
 if [[ "$action" == "prepare_matbench" ]]; then
-    generate_matbench::get_prometheus
-    generate_matbench::prepare_matrix_benchmarking
+	generate_matbench::get_prometheus
+	generate_matbench::prepare_matrix_benchmarking
 
 elif [[ "$action" == "generate_plots" ]]; then
-    generate_matbench::generate_visualizations
+	generate_matbench::generate_visualizations
 
 elif [[ "$action" == "from_dir" ]]; then
-    dir=${2:-}
+	dir=${2:-}
 
-    if [[ -z "$dir" ]]; then
-        _error "no directory provided in 'from_dir' mode, cannot continue."
-        exit 1 # shouldn't be reached
-    fi
-    export MATBENCH_RESULTS_DIRNAME="$dir"
+	if [[ -z "$dir" ]]; then
+		_error "no directory provided in 'from_dir' mode, cannot continue."
+		exit 1 # shouldn't be reached
+	fi
+	export MATBENCH_RESULTS_DIRNAME="$dir"
 
-    generate_matbench::get_prometheus
-    generate_matbench::prepare_matrix_benchmarking
+	generate_matbench::get_prometheus
+	generate_matbench::prepare_matrix_benchmarking
 
-    generate_matbench::generate_visualizations
+	generate_matbench::generate_visualizations
 
 elif [[ "$action" == "from_pr_args" ]]; then
-    generate_matbench::get_prometheus
-    generate_matbench::prepare_matrix_benchmarking
+	generate_matbench::get_prometheus
+	generate_matbench::prepare_matrix_benchmarking
 
-    export MATBENCH_RESULTS_DIRNAME="/tmp/matrix_benchmarking_results"
-    _get_data_from_pr
+	export MATBENCH_RESULTS_DIRNAME="/tmp/matrix_benchmarking_results"
+	_get_data_from_pr
 
-    generate_matbench::generate_visualizations
+	generate_matbench::generate_visualizations
 
 else
-    _error "unknown action='$action' (JOB_NAME_SAFE='${JOB_NAME_SAFE:-}')"
-    exit 1 # shouldn't be reached
+	_error "unknown action='$action' (JOB_NAME_SAFE='${JOB_NAME_SAFE:-}')"
+	exit 1 # shouldn't be reached
 fi

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
@@ -1,17 +1,39 @@
 import json
 import logging
+import numpy as np
+
+from copy import deepcopy
 
 import matrix_benchmarking.common as common
-
+import matrix_benchmarking.regression as regression
 
 def run():
-    logging.info(f"Received {common.Matrix.count_records()} new entries")
-    for entry in common.Matrix.all_records():
-        pass
 
     logging.info(f"Received {common.LTS_Matrix.count_records()} historic LTS entries")
-    for lts_entry in common.LTS_Matrix.all_records(): pass
+    lts_entries_raw = list(common.LTS_Matrix.all_records())
+    # Temporarily skip the gathered results
+    lts_entries = list(filter(lambda entry: type(entry.results) is not list, lts_entries_raw))
+
+    logging.info(f"Received {common.Matrix.count_records()} new entries")
+    new_entries = list(common.Matrix.all_records())
 
     number_of_failures = 0
+    for entry in common.Matrix.all_records():
+        regression_results_dest = entry.location / "regression.json"
+
+        # Check for regression over the image
+        zscore = regression.ZScoreIndicator(
+            entry,
+            lts_entries,
+            settings_filter={"image": "tensorflow:2023.1"},
+            combine_funcs={"notebook_performance_benchmark_time": np.mean}
+        )
+
+        logging.info(f"Saving the regression results in {regression_results_dest}")
+        regression_results = zscore.analyze()
+        with open(regression_results_dest, "w") as f:
+            json.dump(regression_results, f, indent=4)
+            print("", file=f)
+        number_of_failures += sum(map(lambda x: x["regression"]["status"], regression_results))
 
     return number_of_failures

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
@@ -16,7 +16,7 @@ def run():
     logging.info(f"Received {common.Matrix.count_records()} new entries")
 
     number_of_failures = 0
-    settings_to_check = ["rhoai_version"]
+    settings_to_check = ["rhoai_version", "ocp_version"]
     for entry in common.Matrix.all_records():
         regression_results_dest = entry.location / "regression.json"
         regression_results: List[models.RegressionResult] = []

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 import matrix_benchmarking.common as common
 import matrix_benchmarking.regression as regression
+import matrix_benchmarking.regression.zscore as zscore
 
 def run():
 
@@ -41,8 +42,8 @@ def run():
                     lts_entries
                 )
             )
-            zscore = regression.ZScoreIndicator(entry, controlled_lts_entries)
-            regression_results[check_setting] = zscore.analyze()
+            zscore_ind = zscore.ZScoreIndicator(entry, controlled_lts_entries)
+            regression_results[check_setting] = zscore_ind.analyze()
             number_of_failures += sum(map(lambda x: x["regression"]["status"], regression_results[check_setting]))
 
         logging.info(f"Saving the regression results in {regression_results_dest}")

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
@@ -27,8 +27,7 @@ def run():
             except KeyError:
                 logging.warning(f"Couldn't find {check_setting} setting for entry={entry.location}, skipping...")
                 continue
-            
-            controlled_settings = {"image_name": "pytorch"}
+
 
             controlled_lts_entries = list(
                 filter(

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
@@ -16,7 +16,7 @@ def run():
     logging.info(f"Received {common.Matrix.count_records()} new entries")
 
     number_of_failures = 0
-    settings_to_check = ["rhoai_version", "image_name"]
+    settings_to_check = ["rhoai_version"]
     for entry in common.Matrix.all_records():
         regression_results_dest = entry.location / "regression.json"
         regression_results: List[models.RegressionResult] = []
@@ -27,6 +27,8 @@ def run():
             except KeyError:
                 logging.warning(f"Couldn't find {check_setting} setting for entry={entry.location}, skipping...")
                 continue
+            
+            controlled_settings = {"image_name": "pytorch"}
 
             controlled_lts_entries = list(
                 filter(

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
@@ -21,17 +21,13 @@ def run():
         regression_results_dest = entry.location / "regression.json"
         regression_results: List[models.RegressionResult] = []
         for check_setting in settings_to_check:
-            controlled_settings = dict(entry.get_settings())
-            try:
-                controlled_settings.pop(check_setting)
-            except KeyError:
-                logging.warning(f"Couldn't find {check_setting} setting for entry={entry.location}, skipping...")
-                continue
-
+            # This will likely need to be updated with the settings that must be equal between entries
+            # for them to be considered similar enough for comparison against LTS entries
+            controlled_settings = {setting: dict(entry.get_settings())[setting] for setting in ["ocp_version"]}
 
             controlled_lts_entries = list(
                 filter(
-                    lambda x: regression.dict_part_eq(controlled_settings, x.get_settings()),
+                    lambda x: regression.dict_part_eq(controlled_settings, dict(x.get_settings())),
                     lts_entries
                 )
             )

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/analyze/__init__.py
@@ -11,6 +11,7 @@ def run():
 
     logging.info(f"Received {common.LTS_Matrix.count_records()} historic LTS entries")
     lts_entries = []
+    # Take the first result if they were gathered
     for entry in common.LTS_Matrix.all_records():
         if entry.results and type(entry.results) is list:
             entry.results = entry.results[0]
@@ -21,20 +22,28 @@ def run():
     logging.info(f"Received {common.Matrix.count_records()} new entries")
 
     number_of_failures = 0
+    settings_to_check = ["version", "repeat"]
     for entry in common.Matrix.all_records():
         regression_results_dest = entry.location / "regression.json"
-        regression_results = []
-        controlled_settings = entry.get_settings()
-        controlled_settings.pop("repeat") # Looking for regressions over the version, repeat is a placeholder
-        controlled_lts_entries = list(
-            filter(
-                lambda x: regression.dict_part_eq(controlled_settings, x.get_settings()),
-                lts_entries
+        regression_results = {}
+        for check_setting in settings_to_check:
+            controlled_settings = entry.get_settings()
+
+            try:
+                controlled_settings.pop(check_setting)
+            except KeyError:
+                logging.warning(f"Couldn't find {check_setting} setting for entry={entry.location}, skipping...")
+                continue
+
+            controlled_lts_entries = list(
+                filter(
+                    lambda x: regression.dict_part_eq(controlled_settings, x.get_settings()),
+                    lts_entries
+                )
             )
-        )
-        zscore = regression.ZScoreIndicator(entry, controlled_lts_entries)
-        regression_results = zscore.analyze()
-        number_of_failures += sum(map(lambda x: x["regression"]["status"], regression_results))
+            zscore = regression.ZScoreIndicator(entry, controlled_lts_entries)
+            regression_results[check_setting] = zscore.analyze()
+            number_of_failures += sum(map(lambda x: x["regression"]["status"], regression_results[check_setting]))
 
         logging.info(f"Saving the regression results in {regression_results_dest}")
         with open(regression_results_dest, "w") as f:

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/models/lts.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/models/lts.py
@@ -49,19 +49,19 @@ class BenchmarkMeasures(matbench_models.ExclusiveModel):
 
 class Results(matbench_models.ExclusiveModel):
     benchmark_measures: BenchmarkMeasures
-    regression: NotebookPerformanceRegression
+
 
 class NotebookPerformanceKPI(matbench_models.KPI, Settings): pass
 
 
 NotebookPerformanceKPIs = matbench_models.getKPIsModel("NotebookPerformanceKPIs", __name__, kpi.KPIs, NotebookPerformanceKPI)
-NotebookPerformanceRegression = matbench_models.RegressionResult
 
 class Payload(matbench_models.ExclusiveModel):
     schema_name: matbench_models.create_schema_field("rhods-notebooks-perf") = Field(alias="$schema")
     metadata: Metadata
     results: Results
     kpis: Optional[NotebookPerformanceKPIs]
+    regression: Optional[List[matbench_models.RegressionResult]] = Field(default=None)
 
     class Config:
         fields = {'schema_name': '$schema'}

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/models/lts.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/models/lts.py
@@ -61,7 +61,7 @@ class Payload(matbench_models.ExclusiveModel):
     metadata: Metadata
     results: Results
     kpis: Optional[NotebookPerformanceKPIs]
-    regression: Optional[List[matbench_models.RegressionResult]] = Field(default=None)
+    regression: Optional[List[matbench_models.Regression]] = Field(default=None)
 
     class Config:
         fields = {'schema_name': '$schema'}

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/models/lts.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/models/lts.py
@@ -49,18 +49,19 @@ class BenchmarkMeasures(matbench_models.ExclusiveModel):
 
 class Results(matbench_models.ExclusiveModel):
     benchmark_measures: BenchmarkMeasures
+    regression: NotebookPerformanceRegression
 
 class NotebookPerformanceKPI(matbench_models.KPI, Settings): pass
 
 
 NotebookPerformanceKPIs = matbench_models.getKPIsModel("NotebookPerformanceKPIs", __name__, kpi.KPIs, NotebookPerformanceKPI)
+NotebookPerformanceRegression = matbench_models.RegressionResult
 
 class Payload(matbench_models.ExclusiveModel):
     schema_name: matbench_models.create_schema_field("rhods-notebooks-perf") = Field(alias="$schema")
     metadata: Metadata
     results: Results
     kpis: Optional[NotebookPerformanceKPIs]
-    regression_results: Optional[Any]
 
     class Config:
         fields = {'schema_name': '$schema'}

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/plotting/lts_documentation.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/plotting/lts_documentation.py
@@ -96,7 +96,7 @@ def generateOneLtsDocumentationReport(entry):
 
     regression = []
     regression += [html.H1("regression analysis")]
-    regression += [html.Code(yaml.dump(lts.regression_results, default_flow_style=False), style={"white-space": "pre-wrap"})]
+    regression += [html.Code(yaml.dump(lts.regression, default_flow_style=False), style={"white-space": "pre-wrap"})]
 
     header += [html.Ul(regression)]
 

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/plotting/lts_documentation.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/plotting/lts_documentation.py
@@ -4,6 +4,7 @@ import logging
 import datetime
 import math
 import copy
+import yaml
 
 import statistics as stats
 
@@ -91,7 +92,12 @@ def generateOneLtsDocumentationReport(entry):
     benchmark_measures += [html.Li([html.B("measures:"), html.Code(lts.results.benchmark_measures.measures)])]
 
     results += [html.Ul(benchmark_measures)]
-
     header += [html.Ul(results)]
+
+    regression = []
+    regression += [html.H1("regression analysis")]
+    regression += [html.Code(yaml.dump(lts.regression_results, default_flow_style=False), style={"white-space": "pre-wrap"})]
+
+    header += [html.Ul(regression)]
 
     return header

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/plotting/lts_documentation.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/plotting/lts_documentation.py
@@ -96,7 +96,7 @@ def generateOneLtsDocumentationReport(entry):
 
     regression = []
     regression += [html.H1("regression analysis")]
-    regression += [html.Code(yaml.dump(lts.regression, default_flow_style=False), style={"white-space": "pre-wrap"})]
+    regression += [html.Code(yaml.dump([dict(r) for r in lts.regression], default_flow_style=False), style={"white-space": "pre-wrap"})]
 
     header += [html.Ul(regression)]
 

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
@@ -81,7 +81,7 @@ def generate_lts_results(results):
     results_lts = types.SimpleNamespace()
 
     results_lts.benchmark_measures = models.lts.BenchmarkMeasures.parse_obj(results.notebook_benchmark)
-
+    results_lts.regression = models.lts.NotebookPerformanceRegression.parse_obj(results.regression)
     return results_lts
 
 

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
@@ -17,7 +17,6 @@ def generate_lts_payload(results, import_settings, must_validate=False):
     lts_results = generate_lts_results(results)
 
     # ---
-
     lts_payload = types.SimpleNamespace()
     lts_payload.__dict__["$schema"] = f"urn:rhods-notebooks-perf:{models_lts.VERSION}"
     lts_payload.metadata = lts_metadata
@@ -85,7 +84,7 @@ def generate_lts_results(results):
     return results_lts
 
 def generate_lts_regression(results):
-    regression = getattr(results, "regression", []) # A new payload will not have regression results yet!
+    regression = getattr(results, "regression", []) or [] # A new payload will not have regression results yet!
     regression = [matbench_models.Regression.parse_obj(r) for r in regression]
     return regression
 

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
@@ -86,7 +86,8 @@ def generate_lts_results(results):
 
 def generate_lts_regression(results):
     results_lts = types.SimpleNamespace()
-    results_lts.regression = matbench_models.RegressionResult.parse_obj(results.regression_results)
+    regression_results = [] if not results.regression_results else results.regression_results
+    results_lts = [matbench_models.RegressionResult.parse_obj(r) for r in regression_results]
 
     return results_lts
 

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/store/lts_parser.py
@@ -85,11 +85,9 @@ def generate_lts_results(results):
     return results_lts
 
 def generate_lts_regression(results):
-    results_lts = types.SimpleNamespace()
-    regression_results = [] if not results.regression_results else results.regression_results
-    results_lts = [matbench_models.RegressionResult.parse_obj(r) for r in regression_results]
-
-    return results_lts
+    regression = getattr(results, "regression", []) # A new payload will not have regression results yet!
+    regression = [matbench_models.Regression.parse_obj(r) for r in regression]
+    return regression
 
 def get_kpi_labels(lts_payload):
     kpi_labels = dict(lts_payload.metadata.settings)

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/store/parsers.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/store/parsers.py
@@ -31,6 +31,7 @@ IMPORTANT_FILES = [
     "artifacts-sutest/rhods.createdAt",
 
     "notebook-artifacts/benchmark_measures.json",
+    "regression.json"
 ]
 
 PARSER_VERSION = "2023-05-31"

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/store/parsers.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/store/parsers.py
@@ -53,7 +53,7 @@ def _parse_always(results, dirname, import_settings):
 
     results.from_local_env = _parse_local_env(dirname)
     results.test_config = _parse_test_config(dirname)
-    results.regression_results = _parse_regression_results(dirname)
+    results.regression = _parse_regression_results(dirname)
     results.lts = lts_parser.generate_lts_payload(results, import_settings, must_validate=False)
 
 
@@ -259,7 +259,7 @@ def _parse_start_end_time(dirname):
 def _parse_regression_results(dirname):
     regression_results_file = dirname / "regression.json"
     if not regression_results_file.exists():
-        logging.info(f"{regression_results_file.name} does not exist, ignoring the parsing of the regression analyses results.")
+        logging.info(f"{regression_results_file} does not exist, no new regression results found.")
         return None
 
     with open(regression_results_file) as f:

--- a/projects/notebooks/visualizations/rhods-notebooks-performance/store/parsers.py
+++ b/projects/notebooks/visualizations/rhods-notebooks-performance/store/parsers.py
@@ -299,6 +299,7 @@ def _parse_env(dirname, test_config):
     else:
         from_env.test.test_path = str((current_artifact_dir / dirname).relative_to(base_artifact_dir))
 
+    outside_test_env = os.getenv("OUTSIDE_TEST_ENV")
 
     if ansible_env.get("OPENSHIFT_CI") == "true":
         from_env.test.ci_engine = "OPENSHIFT_CI"
@@ -344,7 +345,7 @@ def _parse_env(dirname, test_config):
             JENKINS_ARTIFACTS=f"https://{jenkins_instance}/{jenkins_job}/{build_number}/artifact/run/{jumphost}/{base_path}/{from_env.test.test_path}"
         )
 
-    if test_config.get("export_artifacts.enabled"):
+    if test_config.get("export_artifacts.enabled") and not outside_test_env:
         bucket = test_config.get("export_artifacts.bucket")
         path_prefix = test_config.get("export_artifacts.path_prefix")
 


### PR DESCRIPTION
This sets up the notebooks performance test to create and use a RegressionIndicator from [this matrix-benchmarking PR](https://github.com/openshift-psap/matrix-benchmarking/pull/121).

The idea is that we can create a number of different indicators from the base RegressionIndicator that provides a generic and flexible result that we can save and process upstream. I created a simple ZScoreIndicator to demonstrate this, it triggers when the new payload's KPI values are more than 3 standard deviations away from the mean value for that KPI among the LTS results. Hopefully we can use this to create a simple wrapper for datastax/Hunter.

There are still 2 work in progress issues to resolve with this PR:
1. **Missing Settings:** Some of the settings for an individual MatrixEntry are only present in the Matrix itself. In our testing payloads, an example would be `version`. I'm not sure why these settings aren't present in the MatrixEntry itself, but as currently written we can only restrict the settings that are present in the MatrixEntry.

2. **Gathered Results:** As discussed some of the LTS payloads have "gathered" results. I wasn't sure how to turn this off and couldn't flatten the `Payload`s since I couldn't deepcopy them.