### PR TITLE
[kserve] Add option to use internal minio for model files

### DIFF
--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -150,13 +150,21 @@ ci_presets:
 
   # ---
 
-
   use_intlab_os:
     matbench.lts.opensearch.index_prefix: "psap-rhoai."
     matbench.lts.opensearch.instance: intlab
 
   use_smoke_os:
     matbench.lts.opensearch.instance: smoke
+
+  # ---
+  # Get models from integration lab minio instead of AWS S3
+  use_intlab_minio:
+    secrets.model_aws_cred: intlab-miniocred
+    kserve.storage_config.region: "us-east-1"
+    kserve.storage_config.endpoint: "minio.app.intlab.redhat.com"
+    kserve.storage_config.use_https: "1"
+    kserve.storage_config.verifyssl: "0"
 
   # ---
 
@@ -241,7 +249,7 @@ secrets:
   s3_ldap_password_file: s3_ldap.passwords
   keep_cluster_password_file: get_cluster.password
   brew_registry_redhat_io_token_file: brew.registry.redhat.io.token
-  aws_cred: .awscred
+  model_aws_cred: .awscred
   kserve_model_secret_settings: watsonx-models.yaml
   opensearch_instances: opensearch.yaml
   aws_credentials: .awscred
@@ -369,7 +377,8 @@ kserve:
     name: storage-config
     region: us-east-1
     endpoint: s3.amazonaws.com
-    use_https: 1
+    usehttps: 1
+    verifyssl: 1
   inference_service:
     validation:
       dataset: projects/llm_load_test/llm-load-test/datasets/openorca_large_subset_010.jsonl

--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -160,7 +160,7 @@ ci_presets:
   # ---
   # Get models from integration lab minio instead of AWS S3
   use_intlab_minio:
-    secrets.model_aws_cred: intlab-miniocred
+    secrets.model_s3_cred: intlab-miniocred
     kserve.storage_config.region: "us-east-1"
     kserve.storage_config.endpoint: "minio.app.intlab.redhat.com"
     kserve.storage_config.use_https: "1"
@@ -249,7 +249,7 @@ secrets:
   s3_ldap_password_file: s3_ldap.passwords
   keep_cluster_password_file: get_cluster.password
   brew_registry_redhat_io_token_file: brew.registry.redhat.io.token
-  model_aws_cred: .awscred
+  model_s3_cred: .awscred
   kserve_model_secret_settings: watsonx-models.yaml
   opensearch_instances: opensearch.yaml
   aws_credentials: .awscred

--- a/projects/kserve/testing/test_scale.py
+++ b/projects/kserve/testing/test_scale.py
@@ -117,13 +117,14 @@ def deploy_storage_configuration(namespace):
     storage_secret_name = config.ci_artifacts.get_config("kserve.storage_config.name")
     region = config.ci_artifacts.get_config("kserve.storage_config.region")
     endpoint = config.ci_artifacts.get_config("kserve.storage_config.endpoint")
-    use_https = config.ci_artifacts.get_config("kserve.storage_config.use_https")
+    usehttps = config.ci_artifacts.get_config("kserve.storage_config.usehttps")
+    verifyssl = config.ci_artifacts.get_config("kserve.storage_config.verifyssl")
 
     access_key = None
     secret_key = None
 
     vault_key = config.ci_artifacts.get_config("secrets.dir.env_key")
-    aws_cred_filename = config.ci_artifacts.get_config("secrets.aws_cred")
+    aws_cred_filename = config.ci_artifacts.get_config("secrets.model_aws_cred")
     aws_cred_file = pathlib.Path(os.environ[vault_key]) / aws_cred_filename
     logging.info(f"Reading AWS credentials from '{aws_cred_filename}' ...")
     with open(aws_cred_file) as f:
@@ -143,7 +144,8 @@ metadata:
   annotations:
     serving.kserve.io/s3-region: "{region}"
     serving.kserve.io/s3-endpoint: "{endpoint}"
-    serving.kserve.io/s3-usehttps: "{use_https}"
+    serving.kserve.io/s3-usehttps: "{usehttps}"
+    serving.kserve.io/s3-verifyssl: "{verifyssl}"
   name: {storage_secret_name}
 stringData:
   AWS_ACCESS_KEY_ID: "{access_key}"

--- a/projects/kserve/testing/test_scale.py
+++ b/projects/kserve/testing/test_scale.py
@@ -124,10 +124,10 @@ def deploy_storage_configuration(namespace):
     secret_key = None
 
     vault_key = config.ci_artifacts.get_config("secrets.dir.env_key")
-    aws_cred_filename = config.ci_artifacts.get_config("secrets.model_aws_cred")
-    aws_cred_file = pathlib.Path(os.environ[vault_key]) / aws_cred_filename
-    logging.info(f"Reading AWS credentials from '{aws_cred_filename}' ...")
-    with open(aws_cred_file) as f:
+    model_s3_cred_filename = config.ci_artifacts.get_config("secrets.model_s3_cred")
+    model_s3_cred_file = pathlib.Path(os.environ[vault_key]) / model_s3_cred_filename
+    logging.info(f"Reading the models S3 credentials from '{model_s3_cred_filename}' ...")
+    with open(model_s3_cred_file) as f:
         for line in f.readlines():
             if line.startswith("aws_access_key_id "):
                 access_key = line.rpartition("=")[-1].strip()
@@ -135,7 +135,7 @@ def deploy_storage_configuration(namespace):
                 secret_key = line.rpartition("=")[-1].strip()
 
     if None in (access_key, secret_key):
-        raise ValueError(f"aws_access_key_id or aws_secret_access_key not found in {aws_cred_file} ...")
+        raise ValueError(f"aws_access_key_id or aws_secret_access_key not found in {model_s3_cred_file} ...")
 
     storage_secret = f"""\
 apiVersion: v1


### PR DESCRIPTION
As discussed on slack, I believe these changes should enable us to use the internal minio S3 service to pull the model files when running the kserve tests in the VPN.