### PR TITLE
[kserve] roles: kserve_deploy_model: do not fail if the model initContainer fails

### DIFF
--- a/projects/kserve/roles/kserve_deploy_model/tasks/main.yml
+++ b/projects/kserve/roles/kserve_deploy_model/tasks/main.yml
@@ -182,6 +182,7 @@
     delay: 30
     register: inference_service_pod_fetching_cmd
     until: inference_service_pod_fetching_cmd.rc != 3
+    ignore_errors: true
 
   - name: Wait for the InferenceService Pod to initialize the model
     shell:


### PR DESCRIPTION
next task should fail anyway

OOM appears in the initContainer. Might not be fatal