### PR TITLE
Add `COLLABORATOR` to the `REQUIRED_AUTHOR_ASSOCIATION`

### DIFF
--- a/testing/utils/openshift_ci/pr_args.sh
+++ b/testing/utils/openshift_ci/pr_args.sh
@@ -89,11 +89,12 @@ else
     last_comment_page_json=$(curl -sSf "$PR_LAST_COMMENT_PAGE_URL")
 fi
 
+REQUIRED_AUTHOR=$(jq -r .user.login <<< "$pr_json")
 REQUIRED_AUTHOR_ASSOCIATION=CONTRIBUTOR
 
 echo "PR comments URL: $PR_COMMENTS_URL" >&2
 last_user_test_comment=$(echo "$last_comment_page_json" \
-                             | jq '.[] | select(.author_association == "'$REQUIRED_AUTHOR_ASSOCIATION'") | .body' \
+                             | jq '.[] | select(.author_association == "'$REQUIRED_AUTHOR_ASSOCIATION'"), select(.user.login == "'$REQUIRED_AUTHOR'") | .body' \
                              | (grep "$test_anchor" || true) \
                              | tail -1 | jq -r)
 

--- a/testing/utils/openshift_ci/pr_args.sh
+++ b/testing/utils/openshift_ci/pr_args.sh
@@ -89,7 +89,7 @@ else
     last_comment_page_json=$(curl -sSf "$PR_LAST_COMMENT_PAGE_URL")
 fi
 
-REQUIRED_AUTHOUR=$(jq -r .user.login <<< "$pr_json")
+REQUIRED_AUTHOR=$(jq -r .user.login <<< "$pr_json")
 REQUIRED_AUTHOR_ASSOCIATION="CONTRIBUTOR"
 
 echo "PR comments URL: $PR_COMMENTS_URL" >&2
@@ -98,10 +98,10 @@ last_user_test_comment=$(echo "$last_comment_page_json" \
 last_user_test_issuer=$(echo "$last_comment_page_json" \
 	                     | jq -r '.[-1] | .user.login')
 last_user_test_issuer_status=$(echo "$last_comment_page_json" \
-			     | jq -r '.[-1] | .user.login == "'$REQUIRED_AUTHOUR'" or .author_association == "'$REQUIRED_AUTHOR_ASSOCIATION'"')
+			     | jq -r '.[-1] | .user.login == "'$REQUIRED_AUTHOR'" or .author_association == "'$REQUIRED_AUTHOR_ASSOCIATION'"')
 
 if [[ -z "$last_user_test_comment" ]] || [[ "$last_user_test_issuer" == "false" ]]; then
-    echo "ERROR: last comment of either from a '$REQUIRED_AUTHOR_ASSOCIATION' or '$REQUIRED_AUTHOUR' could not be found (searching for '$test_anchor') ..." >&2
+    echo "ERROR: last comment of either from a '$REQUIRED_AUTHOR_ASSOCIATION' or '$REQUIRED_AUTHOR' could not be found (searching for '$test_anchor') ..." >&2
     exit 1
 fi
 

--- a/testing/utils/openshift_ci/pr_args.sh
+++ b/testing/utils/openshift_ci/pr_args.sh
@@ -99,7 +99,7 @@ last_user_test_comment=$(echo "$last_comment_page_json" \
                              | tail -1 | jq -r)
 
 if [[ -z "$last_user_test_comment" ]]; then
-    echo "ERROR: last comment of from a '$REQUIRED_AUTHOR_ASSOCIATION' could not be found (searching for '$test_anchor') ..." >&2
+    echo "ERROR: last comment of from a '$REQUIRED_AUTHOR_ASSOCIATION' or author=$REQUIRED_AUTHOR could not be found (searching for '$test_anchor') ..." >&2
     exit 1
 fi
 

--- a/testing/utils/openshift_ci/pr_args.sh
+++ b/testing/utils/openshift_ci/pr_args.sh
@@ -89,16 +89,18 @@ else
     last_comment_page_json=$(curl -sSf "$PR_LAST_COMMENT_PAGE_URL")
 fi
 
-REQUIRED_AUTHOR_ASSOCIATION=CONTRIBUTOR
+REQUIRED_AUTHOR_ASSOCIATION=("CONTRIBUTOR" "COLLABORATOR")
 
 echo "PR comments URL: $PR_COMMENTS_URL" >&2
 last_user_test_comment=$(echo "$last_comment_page_json" \
-                             | jq '.[] | select(.author_association == "'$REQUIRED_AUTHOR_ASSOCIATION'") | .body' \
+                             | jq '.[]
+                             | select(.author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[0]}'", .author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[1]}'")
+                             | .body' \
                              | (grep "$test_anchor" || true) \
                              | tail -1 | jq -r)
 
 if [[ -z "$last_user_test_comment" ]]; then
-    echo "ERROR: last comment of from a '$REQUIRED_AUTHOR_ASSOCIATION' could not be found (searching for '$test_anchor') ..." >&2
+    echo "ERROR: last comment of from a '${REQUIRED_AUTHOR_ASSOCIATION[@]}' could not be found (searching for '$test_anchor') ..." >&2
     exit 1
 fi
 

--- a/testing/utils/openshift_ci/pr_args.sh
+++ b/testing/utils/openshift_ci/pr_args.sh
@@ -103,9 +103,9 @@ last_user_test_issuer_status=$(echo "$last_comment_page_json" \
 if [[ -z "$last_user_test_comment" ]] || [[ "$last_user_test_issuer" == "false" ]]; then
     echo "ERROR: last comment of either from a '$REQUIRED_AUTHOR_ASSOCIATION' or '$REQUIRED_AUTHOUR' could not be found (searching for '$test_anchor') ..." >&2
     exit 1
-else
-    echo "INFO: last test comment '$last_user_test_comment' issued by $last_user_test_issuer"
 fi
+
+echo "INFO: last test comment '$last_user_test_comment' issued by $last_user_test_issuer"
 
 pos_args=$(echo "$last_user_test_comment" |
                (grep "$test_anchor" || true) | cut -d" " -f3- | tr -d '\n' | tr -d '\r')


### PR DESCRIPTION
Basically this lets new members of the repo who has not made any contributions before to run prow CI jobs. Here is the break down of individual commands just to make sure the data that is being returned is in the desired shape.

#### select command
```
[cmusali@cmusali topsail]$ cat issue_comments.json | jq '.[] 
> | select(.author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[0]}'", .author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[1]}'")
>                              | .body'
"/test rhoai-light kserve quick_raw"
"/test rhoai-light kserve quick_raw\r\n\r\n"
"/test rhoai-light kserve quick_raw"


[cmusali@cmusali topsail]$ REQUIRED_AUTHOR_ASSOCIATION=("CONTRIBUTOR")
[cmusali@cmusali topsail]$ cat issue_comments.json | jq '.[] 
| select(.author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[0]}'", .author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[1]}'")
                             | .body'
"/test rhoai-light kserve quick_raw"

[cmusali@cmusali topsail]$ REQUIRED_AUTHOR_ASSOCIATION=("COLLABORATOR")
[cmusali@cmusali topsail]$ cat issue_comments.json | jq '.[] 
| select(.author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[0]}'", .author_association == "'${REQUIRED_AUTHOR_ASSOCIATION[1]}'")
                             | .body'
"/test rhoai-light kserve quick_raw"
"/test rhoai-light kserve quick_raw\r\n\r\n"
```

#### echo command
```
[cmusali@cmusali topsail]$ echo "ERROR: last comment of from a '${REQUIRED_AUTHOR_ASSOCIATION[@]}' could not be found"
ERROR: last comment of from a 'CONTRIBUTOR COLLABORATOR' could not be found

```