### PR TITLE
add mistral-7b-instruct-v02 to tested models

### DIFF
--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -198,6 +198,7 @@ ci_presets:
     - flan-t5-xxl
     - llama-2-13b-chat-hf
     - llama-2-70b-chat-hf
+    - mistral-7b-instruct-v02
     - mpt-7b-instruct2
     - codellama-34b-instruct-hf
     matbench.lts.horreum.test_name: rhoai-kserve-single

--- a/projects/kserve/testing/models/cpt/mistral-7b-instruct-v02.yaml
+++ b/projects/kserve/testing/models/cpt/mistral-7b-instruct-v02.yaml
@@ -1,0 +1,11 @@
+extends: base-standalone-tgis
+serving_runtime:
+    kserve:
+        resource_request:
+            nvidia.com/gpu: 1
+            memory: 80Gi
+        extra_env:
+            MAX_CONCURRENT_REQUESTS: 128
+            MAX_BATCH_SIZE: 96
+inference_service:
+  storage_uri: "s3://psap-hf-models/mistral-7b/mistral-7b"


### PR DESCRIPTION
This should add mistral-7b-instruct-v0.2 to topsail based on my understanding of the configuration in Topsail but I fully expect to need multiple iterations to get the PR in a proper shape. I do not know how to run topsail to test the changes I'm proposing. How do I test running topsail against my branch and the model I'm trying to add?

I did manually deploy the model following the recommended steps and manually ran the validate_model steps to confirm the model could respond to a standard request.