### PR TITLE
[cluster] update rsync url for minio

### DIFF
--- a/projects/cluster/roles/cluster_deploy_minio_s3_server/files/deploy_minio.yaml
+++ b/projects/cluster/roles/cluster_deploy_minio_s3_server/files/deploy_minio.yaml
@@ -68,7 +68,7 @@ spec:
              sleep inf
         env:
         - name: RSYNC_RPM_URL
-          value: "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/rsync-3.1.3-19.el8.x86_64.rpm"
+          value: "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/rsync-3.2.3-20.el9.x86_64.rpm"
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
The previous URL that the `deploy_minio` role was getting RSYNC from looks to have been moved: http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/rsync-3.1.3-19.el8.x86_64.rpm

This is causing the deployed pods to crash. This PR updates the the package to the RPM here:
https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/rsync-3.2.3-20.el9.x86_64.rpm