### PR TITLE
[cluster] roles: cluster_wait_fully_awake: tasks/main: do not succeed if an error was logged on stderr

### DIFF
--- a/projects/cluster/roles/cluster_wait_fully_awake/tasks/main.yml
+++ b/projects/cluster/roles/cluster_wait_fully_awake/tasks/main.yml
@@ -70,7 +70,9 @@
         | .metadata.name'
         || true # never let the command fail
     register: apiservices_unavailable
-    until: not apiservices_unavailable.stdout
+    until:
+    - not apiservices_unavailable.stdout
+    - not apiservices_unavailable.stderr
     retries: 50
     delay: 30
 


### PR DESCRIPTION
… if an error was logged on stderr

Example of a [test](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift-psap_topsail/407/pull-ci-openshift-psap-topsail-main-rhoai-light/1811636193146703872/artifacts/light/prepare/artifacts/002__sutest_rhods__deploy_ods/_ansible.log) that passed when it shouldn't have:
```
2024-07-12 06:13:08,742 p=151 u=psap-ci-runner n=ansible | 
2024-07-12 06:13:08,743 p=151 u=psap-ci-runner n=ansible | <stdout> v1beta1.metrics.k8s.io
2024-07-12 06:13:08,743 p=151 u=psap-ci-runner n=ansible | ==> failed attempt #9/50
2024-07-12 06:13:08,743 p=151 u=psap-ci-runner n=ansible | 
2024-07-12 06:13:39,221 p=151 u=psap-ci-runner n=ansible | 
2024-07-12 06:13:39,221 p=151 u=psap-ci-runner n=ansible | <command>
set -o pipefail;
oc get apiservices -ojson | jq -r '.items[] | select(.status.conditions[] | .type == "Available" and .status == "False") | .metadata.name' || true
</command>
2024-07-12 06:13:39,221 p=151 u=psap-ci-runner n=ansible | 
2024-07-12 06:13:39,221 p=151 u=psap-ci-runner n=ansible | <stderr> The connection to the server api.openshift-psap-topsail-cluster-pool-876vd.psap.aws.rhperfscale.org:6443 was refused - did you specify the right host or port?
2024-07-12 06:13:39,229 p=151 u=psap-ci-runner n=ansible | 
2024-07-12 06:13:39,230 p=151 u=psap-ci-runner n=ansible | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-07-12 06:13:39,230 p=151 u=psap-ci-runner n=ansible | ~~ projects/cluster/roles/cluster_wait_fully_awake/tasks/main.yml:77
2024-07-12 06:13:39,230 p=151 u=psap-ci-runner n=ansible | ~~ TASK: cluster_wait_fully_awake : Ensure that the PackageManifests are available
2024-07-12 06:13:39,230 p=151 u=psap-ci-runner n=ansible | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```