### PR TITLE
Drop `prepare_matbench` function calls from `test_e2e.py`, `test.py` in kserve project

### DIFF
--- a/projects/kserve/testing/test.py
+++ b/projects/kserve/testing/test.py
@@ -104,7 +104,6 @@ def test_ci():
                 logging.info("Not generating the visualization because it isn't activated.")
             elif test_artifact_dir_p[0] is not None:
                 with env.NextArtifactDir("plots"):
-                    visualize.prepare_matbench()
                     generate_plots(test_artifact_dir_p[0])
             else:
                 logging.warning("Not generating the visualization as the test artifact directory hasn't been created.")
@@ -253,7 +252,6 @@ def generate_plots(results_dirname):
                 config.TempValue(config.ci_artifacts, "matbench.lts.opensearch.export.enabled", False),
                 config.TempValue(config.ci_artifacts, "matbench.lts.opensearch.index", f"{index}{prom_index_suffix}")
         ):
-            visualize.prepare_matbench()
 
             with env.NextArtifactDir(f"{prom_workload}__all"):
                 logging.info(f"Generating the plots with workload={prom_workload}")

--- a/projects/kserve/testing/test_e2e.py
+++ b/projects/kserve/testing/test_e2e.py
@@ -346,7 +346,6 @@ def test_one_model(
     else:
         results_dir = env.ARTIFACT_DIR
         with env.NextArtifactDir("plots"):
-            visualize.prepare_matbench()
             import test
             test.generate_plots(results_dir)
 
@@ -636,7 +635,6 @@ def launch_test_consolidated_model(consolidated_model, dedicated_dir=True):
 
 
 def matbenchmark_run_llm_load_test(namespace, llm_load_test_args, model_max_concurrency):
-    visualize.prepare_matbench()
 
     with env.NextArtifactDir("matbenchmark__llm_load_test"):
         benchmark_values = {}


### PR DESCRIPTION
A call to `visualize.prepare_matbench()` installs python package dependencies from a requirements file that is available in the `"matrix-benchmarking"` repository. This function invocation has been making noise in my local testing by failing to resolve the dependencies due to dependencies conflicts and blocking the execution of remaining steps, such as llm-load-test in "kserve-user-test-driver" container.


This is an attempt to remove the function calls to `visualize.prepare_matbench()` from project/kserve testing as the dependencies are already satisfied in the topsail image. But only thing to remember is that, this results `caikit-nlp-client` in using a higher(or latest) version of "requests" library than desired. 


#### How to reproduce it locally
1. Create a python virtual enviroment

       python3 -m venv venv

2. Install packages from the `requrements.txt` for "matrix-benchmarking" and "llm_load_test" projects

       pip3 install -r projects/core/subprojects/matrix-benchmarking/requirements.txt
       pip3 install -r projects/llm_load_test/subprojects/llm-load-test/requirements.txt 

One important observation is that, the commands are terminated with `EXIT CODE: 0` in my workstation but this is not the case in the container where the command the was terminated with NON-ZERO exit code. It looks like the user executing the commands inside the container doesn't have right privileges to make any modifications that are made by the root user during the container image creation time. 

```
sh-5.1$ id
uid=1000730000(1000730000) gid=0(root) groups=0(root),1000730000

sh-5.1$ ls -ld /opt/venv/lib/python3.9/site-packages/requests
drwxr-xr-x. 1 root root 4096 Aug 22 06:48 /opt/venv/lib/python3.9/site-packages/requests
```



#### Errors

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
caikit-nlp-client 0.0.8 requires requests==2.31.0, but you have requests 2.32.3 which is incompatible.


Successfully installed BeautifulSoup4-4.11.2 Events-0.5 Flask-3.0.3 Jinja2-3.1.4 MarkupSafe-2.1.5 Werkzeug-3.0.4 blinker-1.8.2 boto3-1.35.10 botocore-1.35.10 click-8.1.7 contourpy-1.3.0 cycler-0.12.1 dash-2.17.1 dash-core-components-2.0.0 dash-html-components-2.0.0 dash-table-5.0.0 dateparser-1.2.0 fire-0.6.0 fonttools-4.53.1 httmock-1.4.0 importlib-metadata-8.4.0 importlib-resources-6.4.4 itsdangerous-2.2.0 jmespath-1.0.1 kaleido-0.2.1 kiwisolver-1.4.5 matplotlib-3.9.2 nest-asyncio-1.6.0 opensearch-py-2.7.1 pillow-10.4.0 plotly-5.24.0 prometheus-api-client-0.5.5 pydantic-1.10.18 pyparsing-3.1.4 regex-2024.7.24 requests-2.32.3 retrying-1.3.4 s3transfer-0.10.2 soupsieve-2.6 tenacity-9.0.0 termcolor-2.4.0 tzlocal-5.2 urllib3-1.26.20 zipp-3.20.1

```