### PR TITLE
Prepare for OpenShift AI `2.13.0 RC1` regression testing

### DIFF
--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -518,10 +518,10 @@ clusters:
 rhods:
   catalog:
     image: brew.registry.redhat.io/rh-osbs/iib
-    tag: 789353
+    tag: 804339
     channel: fast
-    version: 2.12.0
-    version_name: rc2
+    version: 2.13.0
+    version_name: rc1
     opendatahub: false
     managed_rhoai: false
   operator:


### PR DESCRIPTION
OpenShift AI 2.13.0 RC1 is available for Regression Testing.