### PR TITLE
[fine-tuning] Add caching in the entrypoint script.

### DIFF
--- a/projects/fine_tuning/roles/fine_tuning_run_fine_tuning_job/files/entrypoint/entrypoint.sh
+++ b/projects/fine_tuning/roles/fine_tuning_run_fine_tuning_job/files/entrypoint/entrypoint.sh
@@ -42,7 +42,11 @@ prepare_dataset() {
 
 prepare_dataset
 
-python /mnt/entrypoint/study_dataset.py
+CACHE_FILE="${DATASET_FILE}.study_dataset.cache"
+if [ ! -f "$CACHE_FILE" ]; then
+ python /mnt/entrypoint/study_dataset.py > "$CACHE_FILE"
+fi
+cat "$CACHE_FILE"
 
 echo "# sha256sum of the dataset files"
 sha256sum "$DATASET_SOURCE" "$DATASET_DEST"


### PR DESCRIPTION
The script `study_dataset.py` sometimes takes up to 5 mins. In order to speed up the process, simple caching was introduced to cache the results of the study script.