### PR TITLE
Update actions/upload-artifact to v4.

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           cd ./docs
           make html
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: DocumentationHTML
           path: docs/_build/html/


### PR DESCRIPTION
The `Build docs` action was failing because `actions/upload-artifact@v1` is deprecated, so I updated it to the latest v4. 

Source: [Deprecation notice: v1 and v2 of the artifact actions](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)