### PR TITLE
[cluster] roles: cluster_capture_environment: tasks/main: do not capture the CSV in all the namespaces

### DIFF
--- a/projects/cluster/roles/cluster_capture_environment/tasks/main.yml
+++ b/projects/cluster/roles/cluster_capture_environment/tasks/main.yml
@@ -87,7 +87,3 @@
   shell:
     oc get csv -A --show-labels | grep -v olm.copiedFrom > "{{ artifact_extra_logs_dir }}/csv.status"
   ignore_errors: true
-
-- name: Get the cluster CSV in json
-  shell:
-    oc get csv -A -ojson > "{{ artifact_extra_logs_dir }}/csv.json"


### PR DESCRIPTION
takes too much space in large clusters ... (eg, 450MB in IBM cluster)