### PR TITLE
Add RHOAI guard for fine-tuning

### DIFF
--- a/projects/fine_tuning/testing/test_finetuning.py
+++ b/projects/fine_tuning/testing/test_finetuning.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 
 from projects.core.library import env, config, run, merge_dicts
 from projects.matrix_benchmarking.library import visualize, matbenchmark
+from projects.rhods.library import prepare_rhoai as prepare_rhoai_mod
 
 import prepare_finetuning
 
@@ -308,6 +309,11 @@ def _run_test_and_visualize(test_override_values=None):
         msg = "Cannot do matbenchmarking and multi-model at the same time"
         logging.error(msg)
         raise ValueError(msg)
+
+    if prepare_rhoai_mod.is_rhoai_installed():
+        msg = "RHOAI not installed, cluster not prepared for fine-tuning"
+        logging.error(msg)
+        raise RuntimeError(msg)
 
     test_artifact_dir_p = [None]
     try:

--- a/projects/fine_tuning/testing/test_finetuning.py
+++ b/projects/fine_tuning/testing/test_finetuning.py
@@ -310,8 +310,13 @@ def _run_test_and_visualize(test_override_values=None):
         logging.error(msg)
         raise ValueError(msg)
 
-    if prepare_rhoai_mod.is_rhoai_installed():
+    if not prepare_rhoai_mod.is_rhoai_installed():
         msg = "RHOAI not installed, cluster not prepared for fine-tuning"
+        logging.error(msg)
+        raise RuntimeError(msg)
+
+    if not prepare_rhoai_mod.is_component_deployed("trainingoperator"):
+        msg = "Training Operator not installed, cluster not prepared for fine-tuning"
         logging.error(msg)
         raise RuntimeError(msg)
 

--- a/projects/rhods/library/prepare_rhoai.py
+++ b/projects/rhods/library/prepare_rhoai.py
@@ -110,3 +110,8 @@ def uninstall_servicemesh(mute=True):
 
     for ns in cleanup.get("namespaces", []):
         run.run(f"timeout 300 oc delete ns {ns} --ignore-not-found")
+
+def is_component_deployed(component: str):
+    is_deployed = run.run(f"oc get dsc -ojsonpath='{{.items[0].status.installedComponents.{component}}}'", check=False, capture_stdout=True).stdout == "true"
+
+    return is_deployed


### PR DESCRIPTION
One of the things to precheck before launching a fine-tuning job is to make sure RHOAI is installed in the cluster. This guard does that and exit in case it is not installed.