### PR TITLE
[fine_tuning] testing: test: apply the cluster-profiles even outside of the pure bare-metal clusters

### DIFF
--- a/projects/fine_tuning/testing/test.py
+++ b/projects/fine_tuning/testing/test.py
@@ -44,12 +44,12 @@ def init(ignore_secret_path=False, apply_preset_from_pr_args=True):
     config.project.detect_apply_light_profile(LIGHT_PROFILE)
     is_metal = config.project.detect_apply_metal_profile(METAL_PROFILE)
 
-    if is_metal:
-        metal_profiles = config.project.get_config("clusters.metal_profiles")
-        profile_applied = config.project.detect_apply_cluster_profile(metal_profiles)
+    metal_profiles = config.project.get_config("clusters.metal_profiles")
+    profile_applied = config.project.detect_apply_cluster_profile(metal_profiles)
 
-        if not profile_applied:
-            raise ValueError("Bare-metal cluster not recognized :/ ")
+    if is_metal and not profile_applied:
+        raise ValueError("Bare-metal cluster not recognized :/ ")
+
 
 def entrypoint(ignore_secret_path=False, apply_preset_from_pr_args=True):
     def decorator(fct):


### PR DESCRIPTION
Before this PR, the `metal_profiles` field was used to apply cluster-specific CI presets when a given bare-metal cluster was detected (by searching a known node name in the cluster nodes). This worked only for BareMetal cluster infrastructures (and no defined infrastructure).
Running in a bare-metal cluster without a cluster-profile would raise an exception, so that the cluster name/type is always set via the custom profile. The reason for that is that the cluster type is a critical value to include in the test KPIs.

With this PR, the `metal_profiles` are always looked up and applied (if found). But the exception is still raised only if no cluster profile is found in a baremetal cluster.
