### PR TITLE
[kserve] Update to RHOAI 2.15

### DIFF
--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -522,9 +522,9 @@ clusters:
 rhods:
   catalog:
     image: brew.registry.redhat.io/rh-osbs/iib
-    tag: 832635
+    tag: 848124
     channel: fast
-    version: 2.14.0
+    version: 2.15.0
     version_name: rc1
     opendatahub: false
     managed_rhoai: false

--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -303,6 +303,11 @@ ci_presets:
   vllm_cpt_single_model_gating:
     extends: [e2e_perf, gating, 3min, raw, use_intlab_minio, vllm]
     tests.e2e.models:
+    - name: granite-3-0-8b-instruct
+      model: granite-3.0-8b-instruct
+      testing:
+        size: small
+        max_concurrency: 64
     - name: llama-3-8b-instruct
       testing:
        size: small
@@ -522,10 +527,10 @@ clusters:
 rhods:
   catalog:
     image: brew.registry.redhat.io/rh-osbs/iib
-    tag: 848124
+    tag: 852859
     channel: fast
     version: 2.15.0
-    version_name: rc1
+    version_name: rc2
     opendatahub: false
     managed_rhoai: false
   operator:

--- a/projects/kserve/toolbox/kserve_deploy_model/files/vllm/models/granite-3.0-8b-instruct/kustomization.yaml
+++ b/projects/kserve/toolbox/kserve_deploy_model/files/vllm/models/granite-3.0-8b-instruct/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: granite-3-0-8b-instruct-
+
+resources:
+- ../../base
+
+patches:
+- path: patch.yaml
+  target:
+    kind: InferenceService
+  options:
+    allowNameChange: true

--- a/projects/kserve/toolbox/kserve_deploy_model/files/vllm/models/granite-3.0-8b-instruct/patch.yaml
+++ b/projects/kserve/toolbox/kserve_deploy_model/files/vllm/models/granite-3.0-8b-instruct/patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: isvc
+spec:
+  predictor:
+    minReplicas: 1
+    model:
+      storageUri: s3://psap-hf-models/granite-3.0-8b-instruct/
+      resources:
+        requests:
+          cpu: "2"
+          memory: "16Gi"
+          nvidia.com/gpu: "1"
+        limits:
+          nvidia.com/gpu: "1"

--- a/projects/kserve/toolbox/kserve_deploy_model/files/vllm/models/granite-3.0-8b-instruct/patch.yaml
+++ b/projects/kserve/toolbox/kserve_deploy_model/files/vllm/models/granite-3.0-8b-instruct/patch.yaml
@@ -6,7 +6,7 @@ spec:
   predictor:
     minReplicas: 1
     model:
-      storageUri: s3://psap-hf-models/granite-3.0-8b-instruct/
+      storageUri: s3://psap-hf-models/ibm-granite/granite-3.0-8b-instruct/
       resources:
         requests:
           cpu: "2"


### PR DESCRIPTION
Updated `tag` and `version` fields in `kserve/config.yaml` file for OpenShift AI 2.15.0 RC1 model serving performance validation. 

I will use the exiting CI presents `"cpt_single_model_gating"` and `"vllm_cpt_single_model_gating"` to deploy LLMs using "TGIS standalone servingruntime" & "vLLM ServingRuntime" when launching e2e CPT tests through topsail from middleware CI.