### PR TITLE
Clean fms-hf-tuning entrypoint

### DIFF
--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
@@ -19,16 +19,3 @@ if [[ $WORLD_SIZE == 1 ]]; then
     time python /app/accelerate_launch.py
     exit 0
 fi
-echo "Running on $WORLD_SIZE machines with $NUM_GPUS GPUs each."
-
-time accelerate launch \
-     --debug \
-     --machine_rank $RANK \
-     --num_machines $WORLD_SIZE \
-     --num_processes $WORLD_SIZE \
-     --main_process_ip $MASTER_ADDR \
-     --main_process_port $MASTER_PORT \
-     --mixed_precision no \
-     --dynamo_backend no \
-     --multi_gpu \
-     launch_training.py

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
@@ -8,14 +8,17 @@ set -x
 
 export SFT_TRAINER_CONFIG_JSON_PATH=$CONFIG_JSON_PATH
 
-if [[ $WORLD_SIZE == 1 ]]; then
-    echo "Running on a single machine."
-
-    if [[ -z "${NUM_GPUS:-1}" || "${NUM_GPUS:-1}" == 1 ]]; then
-        echo "Running with a single GPU"
-    else
-        echo "Running with a $NUM_GPUS GPUs"
-    fi
-    time python /app/accelerate_launch.py
-    exit 0
+if [[ $WORLD_SIZE != 1 ]]; then
+    echo "Running with a multi-node configuration. This is not supported at the moment, aborting."
+    exit 1
 fi
+
+echo "Running on a single machine."
+
+if [[ -z "${NUM_GPUS:-1}" || "${NUM_GPUS:-1}" == 1 ]]; then
+    echo "Running with a single GPU"
+else
+    echo "Running with a $NUM_GPUS GPUs"
+fi
+
+time python /app/accelerate_launch.py


### PR DESCRIPTION
As per [this PR](https://github.com/foundation-model-stack/fms-hf-tuning/commit/0888ce2b39946c9c8b1a93f0a086156bb8bc016b), the `launch_training.py` script was removed and all trainings are launched by calling `sft_trainer` module directly. 