### PR TITLE
[jump_ci] toolbox: jump_ci_prepare_topsail: tasks/main: force update the submodules

### DIFF
--- a/projects/jump_ci/toolbox/jump_ci_prepare_topsail/tasks/main.yml
+++ b/projects/jump_ci/toolbox/jump_ci_prepare_topsail/tasks/main.yml
@@ -91,7 +91,7 @@
 
   - name: Fetch the submodules
     command: |
-      {{ git }} submodule --quiet update --init --recursive
+      {{ git }} submodule --quiet update --init --recursive --force
 
   - name: Show the submodules version
     command: |
@@ -161,7 +161,7 @@
 
     RUN git fetch --quiet origin {{ git_ref }}
     RUN git reset --hard FETCH_HEAD
-    RUN git submodule --quiet update --init --recursive
+    RUN git submodule --quiet update --init --recursive --force
     RUN git submodule
     EOF
 


### PR DESCRIPTION
Prevents [this error](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift-psap_topsail/650/pull-ci-openshift-psap-topsail-main-jump-ci/1882518904341794816/artifacts/ci/002-prepare-jump-ci/artifacts/001__jump_ci__prepare_topsail/_ansible.log):
```
 <stderr> error: Your local changes to the following files would be overwritten by checkout:
<stderr> 	matrix_benchmarking/analyze/report.py
<stderr> Please commit your changes or stash them before you switch branches.
<stderr> Aborting
<stderr> fatal: Unable to checkout '1dfbdc2dd561df5d69d903680ec5b25050c17809' in submodule path 'projects/matrix_benchmarking/subproject'
<stderr> Error: error building at STEP "RUN git submodule --quiet update --init --recursive": error while running runtime: exit status 1
```