### PR TITLE
[fine_tuning]: Add fine-tuning pod file retrieval

### DIFF
--- a/docs/toolbox.generated/Fine_Tuning.run_fine_tuning_job.rst
+++ b/docs/toolbox.generated/Fine_Tuning.run_fine_tuning_job.rst
@@ -168,3 +168,8 @@ Parameters
 
 * If enabled, activates the host network
 
+
+``retrieve_files``  
+
+* If enabled, allows files retrieval from the pod to the artifacts directory.
+

--- a/docs/toolbox.generated/Fine_Tuning.run_fine_tuning_job.rst
+++ b/docs/toolbox.generated/Fine_Tuning.run_fine_tuning_job.rst
@@ -173,3 +173,5 @@ Parameters
 
 * If enabled, allows files retrieval from the pod to the artifacts directory.
 
+* default value: ``True``
+

--- a/projects/fine_tuning/toolbox/fine_tuning.py
+++ b/projects/fine_tuning/toolbox/fine_tuning.py
@@ -50,7 +50,7 @@ class Fine_Tuning:
             use_secondary_nic=False,
             use_host_network=False,
 
-            retrieve_files=False,
+            retrieve_files=True,
     ):
         """
         Run a simple fine-tuning Job.

--- a/projects/fine_tuning/toolbox/fine_tuning.py
+++ b/projects/fine_tuning/toolbox/fine_tuning.py
@@ -49,6 +49,8 @@ class Fine_Tuning:
             use_primary_nic=True,
             use_secondary_nic=False,
             use_host_network=False,
+
+            retrieve_files=False,
     ):
         """
         Run a simple fine-tuning Job.
@@ -87,6 +89,8 @@ class Fine_Tuning:
           use_primary_nic: if enabled, tell NCCL to use the primary NIC. Only taken into account if --use_secondary_nic is passed.
           use_secondary_nic: if enabled, activates the secondary NIC. Can be a list with the name of multiple NetworkDefinitionAttachements, in the same namespace.
           use_host_network: if enabled, activates the host network
+
+          retrieve_files: if enabled, allows files retrieval from the pod to the artifacts directory.
         """
 
         if use_host_network and use_secondary_nic:

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/defaults/main/config.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/defaults/main/config.yml
@@ -89,3 +89,6 @@ fine_tuning_run_fine_tuning_job_use_secondary_nic: false
 
 # if enabled, activates the host network
 fine_tuning_run_fine_tuning_job_use_host_network: false
+
+# if enabled, allows files retrieval from the pod to the artifacts directory.
+fine_tuning_run_fine_tuning_job_retrieve_files: false

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/defaults/main/config.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/defaults/main/config.yml
@@ -91,4 +91,4 @@ fine_tuning_run_fine_tuning_job_use_secondary_nic: false
 fine_tuning_run_fine_tuning_job_use_host_network: false
 
 # if enabled, allows files retrieval from the pod to the artifacts directory.
-fine_tuning_run_fine_tuning_job_retrieve_files: false
+fine_tuning_run_fine_tuning_job_retrieve_files: true

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/entrypoint.sh
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/entrypoint.sh
@@ -83,8 +83,11 @@ else
 fi
 
 if [[ -n "${RETRIEVE:-}" ]] && [[ "$RANK" -eq 0 ]]; then
-    rm -rf "/mnt/storage/output/*"
-    echo "Emptied output directory: /mnt/storage/output"
+    if [[ -d "$RETRIEVE" ]]; then
+        rm -rf "$RETRIEVE"
+    fi
+    mkdir -p "$RETRIEVE"
+    echo "Emptied output directory: ${RETRIEVE}"
 fi
 
 if [[ "${WORKLOAD:-}" == fms ]]; then

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/entrypoint.sh
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/entrypoint.sh
@@ -82,6 +82,11 @@ else
     echo "No GPU seem to be available."
 fi
 
+if [[ -n "${RETRIEVE:-}" ]] && [[ "$RANK" -eq 0 ]]; then
+    rm -rf "/mnt/storage/output/*"
+    echo "Emptied output directory: /mnt/storage/output"
+fi
+
 if [[ "${WORKLOAD:-}" == fms ]]; then
     CMD="bash $THIS_DIR/run_fms.sh"
 elif [[ "${WORKLOAD:-}" == ilab ]]; then

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
@@ -8,8 +8,6 @@ set -x
 
 export SFT_TRAINER_CONFIG_JSON_PATH=$CONFIG_JSON_PATH
 
-RETRIEVE_FILES=()
-
 if [[ $WORLD_SIZE != 1 ]]; then
     echo "Running with a multi-node configuration. This is not supported at the moment, aborting."
     exit 1
@@ -25,16 +23,6 @@ fi
 
 time python /app/accelerate_launch.py
 
-if [[ -n "${RETRIEVE:-}" ]] && [[ "$RANK" -eq 0 ]] && [[ -n "${RETRIEVE_FILES:-}" ]]; then
-    for file in "${RETRIEVE_FILES[@]}"; do
-        if [[ -f "$file" ]]; then
-            if cp "$file" "/mnt/storage/output/"; then
-                echo "File $file copied to output directory"
-            else
-                echo "Failed to copy $file" >&2
-            fi
-        else
-            echo "File $file not found" >&2
-        fi
-    done
+if [[ -n "${RETRIEVE:-}" ]] && [[ "$RANK" -eq 0 ]]; then
+    cp /etc/os-release "$RETRIEVE"
 fi

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
@@ -8,6 +8,8 @@ set -x
 
 export SFT_TRAINER_CONFIG_JSON_PATH=$CONFIG_JSON_PATH
 
+RETRIEVE_FILES=()
+
 if [[ $WORLD_SIZE != 1 ]]; then
     echo "Running with a multi-node configuration. This is not supported at the moment, aborting."
     exit 1
@@ -22,3 +24,17 @@ else
 fi
 
 time python /app/accelerate_launch.py
+
+if [[ -n "${RETRIEVE:-}" ]] && [[ "$RANK" -eq 0 ]] && [[ -n "${RETRIEVE_FILES:-}" ]]; then
+    for file in "${RETRIEVE_FILES[@]}"; do
+        if [[ -f "$file" ]]; then
+            if cp "$file" "/mnt/storage/output/"; then
+                echo "File $file copied to output directory"
+            else
+                echo "Failed to copy $file" >&2
+            fi
+        else
+            echo "File $file not found" >&2
+        fi
+    done
+fi

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/files/entrypoint/run_fms.sh
@@ -24,5 +24,6 @@ fi
 time python /app/accelerate_launch.py
 
 if [[ -n "${RETRIEVE:-}" ]] && [[ "$RANK" -eq 0 ]]; then
+    # NOTE: Write here the code to copy any file you want to export to the test artifacts
     cp /etc/os-release "$RETRIEVE"
 fi

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -366,44 +366,32 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
   - name: Retrieve Pod files to artifacts directory
     when: fine_tuning_run_fine_tuning_job_retrieve_files | bool
     block:
-      - name: Launch fine-tuning-file-retrieval Pod
-        shell:
+      - name: Create the Pod artifacts directory
+        file:
+          path: "{{ artifact_extra_logs_dir }}/pod-artifacts/"
+          state: directory
+          mode: '0755'
+
+      - name: Launch fine-tuning-file-retrieval Pod from template
+        command:
+          oc create -f <(echo "{{ fine_tuning_job_retrieval_pod_template | to_json }}")
+
+      - name: Wait for fine-tuning-file-retrieval Pod to be Running
+        command:
           set -o pipefail;
 
-          cat << EOF | oc create -f -
-{
-  "apiVersion": "v1",
-  "kind": "Pod",
-  "metadata": {
-    "name": "fine-tuning-file-retrieval"
-  },
-  "spec": {
-    "containers": [
-      {
-        "name": "cnt",
-        "image": "{{ fine_tuning_run_fine_tuning_job_container_image }}",
-        "volumeMounts": [
-          {
-            "name": "storage",
-            "mountPath": "/mnt"
-          }
-        ]
-      }
-    ],
-    "volumes": [
-      {
-        "name": "storage",
-        "persistentVolumeClaim": {
-          "claimName": "{{ fine_tuning_run_fine_tuning_job_pvc_name }}"
-        }
-      }
-    ]
-  }
-}
-EOF
-      - name: Copy files to artifacts directory
+          oc get pod --no-headers
+             fine-tuning-file-retrieval
+             -n {{ fine_tuning_run_fine_tuning_job_namespace }}
+             | awk '{print $3}'
+        register: retrieve_pod_state_cmd
+        until: '"Running" not in retrieve_pod_state_cmd.stdout_lines'
+        retries: 18
+        delay 10
+
+      - name: Copy files to the Pod artifacts directory
         command:
-          oc cp fine-tuning-file-retrieval:/mnt/storage/output/ "{{ artifact_extra_logs_dir }}/artifacts/"
+          oc cp fine-tuning-file-retrieval:/mnt/storage/output/ "{{ artifact_extra_logs_dir }}/pod-artifacts/"
 
       - name: Delete fine-tuning-file-retrieval Pod
         command:

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -366,41 +366,51 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
   - name: Retrieve Pod files to artifacts directory
     when: fine_tuning_run_fine_tuning_job_retrieve_files | bool
     block:
-      - name: Create the Pod artifacts directory
-        file:
-          path: "{{ artifact_extra_logs_dir }}/pod-artifacts/"
-          state: directory
-          mode: '0755'
+    - name: Create the Pod artifacts directory
+      file:
+        path: "{{ artifact_extra_logs_dir }}/pod-artifacts/"
+        state: directory
+        mode: '0755'
 
-      - name: Prepare the retrieval Pod template
-        template:
-          src: "{{ fine_tuning_job_retrieval_pod_template}}"
-          dest: "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
-          mode: '0400'
+    - name: Prepare the retrieval Pod template
+      template:
+        src: "{{ fine_tuning_job_retrieval_pod_template }}"
+        dest: "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
+        mode: '0400'
 
-      - name: Launch fine-tuning-file-retrieval Pod from template
-        command:
-          oc create -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
+    - name: Launch fine-tuning-file-retrieval Pod from template
+      command:
+        oc create -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
 
-      - name: Wait for fine-tuning-file-retrieval Pod to be Running
-        shell:
-          set -o pipefail;
+    - name: Wait for fine-tuning-file-retrieval Pod to be Running
+      shell:
+        set -o pipefail;
 
-          oc get --no-headers
-             -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
-             | awk '{print $3}'
-        register: retrieve_pod_state_cmd
-        until: '"Running" not in retrieve_pod_state_cmd.stdout_lines'
-        retries: 18
-        delay: 10
+        oc get --no-headers
+           -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
+           | awk '{print $3}'
+      register: retrieve_pod_state_cmd
+      until: '"Running" in retrieve_pod_state_cmd.stdout_lines'
+      retries: 18
+      delay: 10
 
-      - name: Copy files to the Pod artifacts directory
-        command:
-          oc cp fine-tuning-file-retrieval:{{ fine_tuning_job_retrieval_output_dir }}
-             "{{ artifact_extra_logs_dir }}/pod-artifacts/"
-             -n {{ fine_tuning_run_fine_tuning_job_namespace }}
+    - name: Copy files to the Pod artifacts directory
+      command:
+        oc cp fine-tuning-file-retrieval:{{ fine_tuning_job_retrieval_output_dir }}
+           "{{ artifact_extra_logs_dir }}/pod-artifacts/"
+           -n {{ fine_tuning_run_fine_tuning_job_namespace }}
 
     always:
-      - name: Delete fine-tuning-file-retrieval Pod
-        command:
-          oc delete -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
+    - name: Delete fine-tuning-file-retrieval Pod
+      shell:
+        oc get -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
+           > "{{ artifact_extra_logs_dir }}/retrieval_pod.status";
+
+        oc get -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
+           -oyaml
+           > "{{ artifact_extra_logs_dir }}/retrieval_pod.yaml";
+
+        oc describe -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
+           > "{{ artifact_extra_logs_dir }}/retrieval_pod.descr";
+
+        oc delete -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml";

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -372,17 +372,22 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
           state: directory
           mode: '0755'
 
+      - name: Prepare the retrieval Pod template
+        template:
+          src: "{{ fine_tuning_job_retrieval_pod_template}}"
+          dest: "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"
+          mode: '0400'
+
       - name: Launch fine-tuning-file-retrieval Pod from template
         command:
-          oc create -f <(echo "{{ fine_tuning_job_retrieval_pod_template | to_json }}")
+          oc create -f "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"
 
       - name: Wait for fine-tuning-file-retrieval Pod to be Running
         command:
           set -o pipefail;
 
           oc get pod --no-headers
-             fine-tuning-file-retrieval
-             -n {{ fine_tuning_run_fine_tuning_job_namespace }}
+             -f "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"
              | awk '{print $3}'
         register: retrieve_pod_state_cmd
         until: '"Running" not in retrieve_pod_state_cmd.stdout_lines'
@@ -391,8 +396,11 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
 
       - name: Copy files to the Pod artifacts directory
         command:
-          oc cp fine-tuning-file-retrieval:/mnt/storage/output/ "{{ artifact_extra_logs_dir }}/pod-artifacts/"
+          oc cp fine-tuning-file-retrieval:{{ fine_tuning_job_retrieval_output_dir }}
+             "{{ artifact_extra_logs_dir }}/pod-artifacts/"
+             -n {{ fine_tuning_run_fine_tuning_job_namespace }}
 
+    always:
       - name: Delete fine-tuning-file-retrieval Pod
         command:
-          oc delete pod fine-tuning-file-retrieval
+          oc delete -f "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -387,7 +387,7 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
         register: retrieve_pod_state_cmd
         until: '"Running" not in retrieve_pod_state_cmd.stdout_lines'
         retries: 18
-        delay 10
+        delay: 10
 
       - name: Copy files to the Pod artifacts directory
         command:

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -375,19 +375,19 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
       - name: Prepare the retrieval Pod template
         template:
           src: "{{ fine_tuning_job_retrieval_pod_template}}"
-          dest: "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"
+          dest: "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
           mode: '0400'
 
       - name: Launch fine-tuning-file-retrieval Pod from template
         command:
-          oc create -f "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"
+          oc create -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
 
       - name: Wait for fine-tuning-file-retrieval Pod to be Running
         command:
           set -o pipefail;
 
           oc get pod --no-headers
-             -f "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"
+             -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
              | awk '{print $3}'
         register: retrieve_pod_state_cmd
         until: '"Running" not in retrieve_pod_state_cmd.stdout_lines'
@@ -403,4 +403,4 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
     always:
       - name: Delete fine-tuning-file-retrieval Pod
         command:
-          oc delete -f "{{ artifact_extra_logs_dir }}/src/revrieval_pod.yaml"
+          oc delete -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -383,7 +383,7 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
           oc create -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
 
       - name: Wait for fine-tuning-file-retrieval Pod to be Running
-        command:
+        shell:
           set -o pipefail;
 
           oc get pod --no-headers

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -362,3 +362,49 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
          > {{ artifact_extra_logs_dir }}/artifacts/pod_{{ item | replace('pod/', '') }}.log
     failed_when: false
     loop: "{{ job_pod_name_cmd.stdout_lines }}"
+
+  - name: Retrieve Pod files to artifacts directory
+    when: fine_tuning_run_fine_tuning_job_retrieve_files | bool
+    block:
+      - name: Launch fine-tuning-file-retrieval Pod
+        shell:
+          set -o pipefail;
+
+          cat << EOF | oc create -f -
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "fine-tuning-file-retrieval"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "cnt",
+        "image": "{{ fine_tuning_run_fine_tuning_job_container_image }}",
+        "volumeMounts": [
+          {
+            "name": "storage",
+            "mountPath": "/mnt"
+          }
+        ]
+      }
+    ],
+    "volumes": [
+      {
+        "name": "storage",
+        "persistentVolumeClaim": {
+          "claimName": "{{ fine_tuning_run_fine_tuning_job_pvc_name }}"
+        }
+      }
+    ]
+  }
+}
+EOF
+      - name: Copy files to artifacts directory
+        command:
+          oc cp fine-tuning-file-retrieval:/mnt/storage/output/ "{{ artifact_extra_logs_dir }}/artifacts/"
+
+      - name: Delete fine-tuning-file-retrieval Pod
+        command:
+          oc delete pod fine-tuning-file-retrieval

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -404,13 +404,13 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
     - name: Delete fine-tuning-file-retrieval Pod
       shell:
         oc get -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
-           > "{{ artifact_extra_logs_dir }}/retrieval_pod.status";
+           > "{{ artifact_extra_logs_dir }}/artifacts/retrieval_pod.status";
 
         oc get -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
            -oyaml
-           > "{{ artifact_extra_logs_dir }}/retrieval_pod.yaml";
+           > "{{ artifact_extra_logs_dir }}/artifacts/retrieval_pod.yaml";
 
         oc describe -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
-           > "{{ artifact_extra_logs_dir }}/retrieval_pod.descr";
+           > "{{ artifact_extra_logs_dir }}/artifacts/retrieval_pod.descr";
 
         oc delete -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml";

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/tasks/main.yml
@@ -386,7 +386,7 @@ elif fine_tuning_run_fine_tuning_job_workload == 'ilab' -%}
         shell:
           set -o pipefail;
 
-          oc get pod --no-headers
+          oc get --no-headers
              -f "{{ artifact_extra_logs_dir }}/src/retrieval_pod.yaml"
              | awk '{print $3}'
         register: retrieve_pod_state_cmd

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
@@ -99,7 +99,7 @@ spec:
                   fieldPath: spec.nodeName
 {% if fine_tuning_run_fine_tuning_retrieve_files %}
             - name: RETRIEVE
-              value: "true"
+              value: "{{ fine_tuning_job_retrieval_output_dir }}"
 {% endif %}
 {% endif %}
             volumeMounts:

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
@@ -97,10 +97,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+{% endif %}
 {% if fine_tuning_run_fine_tuning_retrieve_files %}
             - name: RETRIEVE
               value: "{{ fine_tuning_job_retrieval_output_dir }}"
-{% endif %}
 {% endif %}
             volumeMounts:
             - name: storage-volume

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
@@ -97,6 +97,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+{% if fine_tuning_run_fine_tuning_retrieve_files %}
+            - name: RETRIEVE
+              value: "true"
+{% endif %}
 {% endif %}
             volumeMounts:
             - name: storage-volume

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/fine_tuning_job.yaml.j2
@@ -98,7 +98,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
 {% endif %}
-{% if fine_tuning_run_fine_tuning_retrieve_files %}
+{% if fine_tuning_run_fine_tuning_job_retrieve_files %}
             - name: RETRIEVE
               value: "{{ fine_tuning_job_retrieval_output_dir }}"
 {% endif %}

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
  name: fine-tuning-file-retrieval
+ namespace: {{ fine_tuning_run_fine_tuning_job_namespace }}
 spec:
  containers:
  - name: cnt

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
@@ -10,7 +10,7 @@ spec:
    command: ["sleep", "inf"]
    volumeMounts:
    - name: storage
-     mountPath: /mnt
+     mountPath: {{ fine_tuning_job_retrieval_output_dir }}
  volumes:
  - name: storage
    persistentVolumeClaim:

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
@@ -10,7 +10,7 @@ spec:
    command: ["sleep", "inf"]
    volumeMounts:
    - name: storage
-     mountPath: {{ fine_tuning_job_retrieval_output_dir }}
+     mountPath: {{ fine_tuning_job_retrieval_output_dir | dirname }}
  volumes:
  - name: storage
    persistentVolumeClaim:

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/templates/retrieval_pod.yaml.j2
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+ name: fine-tuning-file-retrieval
+spec:
+ containers:
+ - name: cnt
+   image: {{ fine_tuning_run_fine_tuning_job_container_image }}
+   command: ["sleep", "inf"]
+   volumeMounts:
+   - name: storage
+     mountPath: /mnt
+ volumes:
+ - name: storage
+   persistentVolumeClaim:
+     claimName: {{ fine_tuning_run_fine_tuning_job_pvc_name }}

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/vars/main/resources.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/vars/main/resources.yml
@@ -5,5 +5,6 @@ fine_tuning_job_entrypoint_dir: "{{ role_path }}/files/entrypoint"
 fine_tuning_job_entrypoint_name: entrypoint.sh
 fine_tuning_job_fms_config_template: templates/fms_base_config.yaml.j2
 fine_tuning_job_ilab_config_template: templates/ilab_base_config.yaml.j2
+fine_tuning_job_retrieval_output_dir: "/mnt/storage/output"
 
 __safe: [fine_tuning_job_entrypoint_name]

--- a/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/vars/main/resources.yml
+++ b/projects/fine_tuning/toolbox/fine_tuning_run_fine_tuning_job/vars/main/resources.yml
@@ -5,6 +5,7 @@ fine_tuning_job_entrypoint_dir: "{{ role_path }}/files/entrypoint"
 fine_tuning_job_entrypoint_name: entrypoint.sh
 fine_tuning_job_fms_config_template: templates/fms_base_config.yaml.j2
 fine_tuning_job_ilab_config_template: templates/ilab_base_config.yaml.j2
+fine_tuning_job_retrieval_pod_template: templates/retrieval_pod.yaml.j2
 fine_tuning_job_retrieval_output_dir: "/mnt/storage/output"
 
 __safe: [fine_tuning_job_entrypoint_name]


### PR DESCRIPTION
In order to retrieve files from the fine-tuning Pod execution, we enable by default the `--retrieve-files` flag. 

* The mounting point of the files to be exported as artifacts is [/mnt/storage/output](https://github.com/openshift-psap/topsail/pull/652/files#diff-df818cb4be74252e4ce9361ac6e4c732d2c49b2836aab5266295535037c150d0R9) by default.
* The logic for copying the files is written in the [entrypoint](https://github.com/openshift-psap/topsail/pull/652/files#diff-bc78a290b2c47f14480b1c35286b55175d720ce800bea808f18dc6a2cab835abR27). 
