### PR TITLE
Updated the naming convention, replacing HOMELAB_CI with TOPSAIL_LOCAL_CI

### DIFF
--- a/docs/extending/orchestration.rst
+++ b/docs/extending/orchestration.rst
@@ -493,7 +493,7 @@ S3 server, and stored locally for post-processing.
 
 * ``apply_prefer_pr(pr_number=None)`` inspects the environment to
   detect the PR number. When running locally, export
-  ``HOMELAB_CI=true`` and ``PULL_NUMBER=...`` for this function to
+  ``TOPSAIL_LOCAL_CI=true`` and ``PULL_NUMBER=...`` for this function to
   automatically detect the PR number. Mind that this function updates
   the configuration file, so it cannot run inside a parallel context.
 

--- a/projects/local_ci/library/prepare_user_pods.py
+++ b/projects/local_ci/library/prepare_user_pods.py
@@ -28,11 +28,11 @@ def apply_prefer_pr(pr_number=None):
             logging.warning(f"apply_prefer_pr: PERFLAB_CI: base_image.repo.ref_prefer_pr is set but 'PERFLAB_GIT_REF={git_ref}' cannot be parsed: {e.__class__.__name__}: {e}")
             return
 
-    elif os.environ.get("HOMELAB_CI"):
+    elif os.environ.get("TOPSAIL_LOCAL_CI"):
         pr_number = os.environ.get("PULL_NUMBER")
 
         if not pr_number:
-            raise RuntimeError("apply_prefer_pr: HOMELAB_CI: base_image.repo.ref_prefer_pr is set but PULL_NUMBER is empty")
+            raise RuntimeError("apply_prefer_pr: TOPSAIL_LOCAL_CI: base_image.repo.ref_prefer_pr is set but PULL_NUMBER is empty")
     else:
         logging.warning("apply_prefer_pr: Could not figure out the PR number. Keeping the default value.")
         return

--- a/projects/local_ci/toolbox/local_ci_run/templates/pod.yaml.j2
+++ b/projects/local_ci/toolbox/local_ci_run/templates/pod.yaml.j2
@@ -33,7 +33,7 @@ spec:
       git submodule update --init
 {% endif %}
     env:
-    - name: HOMELAB_CI
+    - name: TOPSAIL_LOCAL_CI
       value: "yes"
     - name: GIT_REPO
       value: "{{ local_ci_run_git_repo }}"


### PR DESCRIPTION
#### Highlights of the PR
* The variable `HOMELAB_CI` has been replaced with `TOPSAIL_LOCAL_CI`, allowing TOPSAIL to build base images from the PR instead of `topsail:main`.