### PR TITLE
Add arguments to llm-load-test toolbox command

### DIFF
--- a/docs/toolbox.generated/Llm_Load_Test.run.rst
+++ b/docs/toolbox.generated/Llm_Load_Test.run.rst
@@ -80,6 +80,16 @@ Parameters
 * default value: ``16``
 
 
+``min_input_tokens``  
+
+* Min input tokens in llm load test to filter the dataset
+
+
+``min_output_tokens``  
+
+* Min output tokens in llm load test to filter the dataset
+
+
 ``max_input_tokens``  
 
 * Max input tokens in llm load test to filter the dataset

--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -662,10 +662,14 @@ tests:
         endpoint: null # only used with openai plugin
       dataset_size:
         small:
+          min_input_tokens: 0
+          min_output_tokens: 0
           max_input_tokens: 2047
           max_output_tokens: 1024
           max_sequence_tokens: 2048
         large:
+          min_input_tokens: 0
+          min_output_tokens: 0
           max_input_tokens: 3500
           max_output_tokens: 800
           max_sequence_tokens: 3500

--- a/projects/llm_load_test/toolbox/llm_load_test.py
+++ b/projects/llm_load_test/toolbox/llm_load_test.py
@@ -24,6 +24,8 @@ class Llm_Load_Test:
             streaming=True,
             use_tls=False,
             concurrency=16,
+            min_input_tokens=0,
+            min_output_tokens=0,
             max_input_tokens=1024,
             max_output_tokens=512,
             max_sequence_tokens=1536,
@@ -44,6 +46,8 @@ class Llm_Load_Test:
           streaming: Whether to stream the llm-load-test requests
           use_tls: Whether to set use_tls: True (grpc in Serverless mode)
           concurrency: Number of concurrent simulated users sending requests
+          min_input_tokens: min input tokens in llm load test to filter the dataset
+          min_output_tokens: min output tokens in llm load test to filter the dataset
           max_input_tokens: max input tokens in llm load test to filter the dataset
           max_sequence_tokens: max sequence tokens in llm load test to filter the dataset
           max_output_tokens: max output tokens in llm load test to filter the dataset

--- a/projects/llm_load_test/toolbox/llm_load_test_run/defaults/main/config.yml
+++ b/projects/llm_load_test/toolbox/llm_load_test_run/defaults/main/config.yml
@@ -36,6 +36,12 @@ llm_load_test_run_use_tls: false
 # Number of concurrent simulated users sending requests
 llm_load_test_run_concurrency: 16
 
+# min input tokens in llm load test to filter the dataset
+llm_load_test_run_min_input_tokens: 0
+
+# min output tokens in llm load test to filter the dataset
+llm_load_test_run_min_output_tokens: 0
+
 # max input tokens in llm load test to filter the dataset
 llm_load_test_run_max_input_tokens: 1024
 

--- a/projects/llm_load_test/toolbox/llm_load_test_run/templates/llm-load-test-config.yaml.j2
+++ b/projects/llm_load_test/toolbox/llm_load_test_run/templates/llm-load-test-config.yaml.j2
@@ -7,7 +7,8 @@ storage:
 dataset:
   file: "datasets/openorca_large_subset_011.jsonl"
   max_queries: 3000
-  min_input_tokens: 0
+  min_input_tokens: {{ llm_load_test_run_min_input_tokens }}
+  min_output_tokens: {{ llm_load_test_run_min_output_tokens }}
   max_input_tokens: {{ llm_load_test_run_max_input_tokens }}
   max_output_tokens: {{ llm_load_test_run_max_output_tokens }}
   max_sequence_tokens: {{ llm_load_test_run_max_sequence_tokens }}


### PR DESCRIPTION
Add the `--min_input_tokens` and `--min_output_tokens` arguments to the `llm-load-test toolbox` command.

Currently, the Topsail run_toolbox.py llm_load_test command lacks these arguments, which are sometimes needed to filter datasets.