### PR TITLE
[llm_load_test] Make more generic for testing on other platforms

### DIFF
--- a/docs/toolbox.generated/Llm_Load_Test.run.rst
+++ b/docs/toolbox.generated/Llm_Load_Test.run.rst
@@ -51,7 +51,7 @@ Parameters
 
 * The ID of the model to pass along with the GRPC call
 
-* default value: ``not-used``
+* default value: ``/mnt/models/``
 
 
 ``src_path``  

--- a/docs/toolbox.generated/Llm_Load_Test.run.rst
+++ b/docs/toolbox.generated/Llm_Load_Test.run.rst
@@ -117,3 +117,10 @@ Parameters
 
 * default value: ``/v1/completions``
 
+
+``python_cmd``  
+
+* Command to use to launch Python
+
+* default value: ``python3``
+

--- a/projects/llm_load_test/toolbox/llm_load_test.py
+++ b/projects/llm_load_test/toolbox/llm_load_test.py
@@ -30,6 +30,7 @@ class Llm_Load_Test:
             max_output_tokens=512,
             max_sequence_tokens=1536,
             endpoint="/v1/completions",
+            python_cmd="python3",
             ):
         """
         Load test the wisdom model
@@ -52,6 +53,7 @@ class Llm_Load_Test:
           max_sequence_tokens: max sequence tokens in llm load test to filter the dataset
           max_output_tokens: max output tokens in llm load test to filter the dataset
           endpoint: name of the endpoint to query (for openai plugin only)
+          python_cmd: command to use to launch Python
         """
 
         return RunAnsibleRole(locals())

--- a/projects/llm_load_test/toolbox/llm_load_test.py
+++ b/projects/llm_load_test/toolbox/llm_load_test.py
@@ -19,7 +19,7 @@ class Llm_Load_Test:
             duration,
             plugin="tgis_grpc_plugin",
             interface="grpc",
-            model_id="not-used",
+            model_id="/mnt/models/",
             src_path="projects/llm_load_test/subprojects/llm-load-test/",
             streaming=True,
             use_tls=False,

--- a/projects/llm_load_test/toolbox/llm_load_test_run/defaults/main/config.yml
+++ b/projects/llm_load_test/toolbox/llm_load_test_run/defaults/main/config.yml
@@ -22,7 +22,7 @@ llm_load_test_run_plugin: tgis_grpc_plugin
 llm_load_test_run_interface: grpc
 
 # The ID of the model to pass along with the GRPC call
-llm_load_test_run_model_id: not-used
+llm_load_test_run_model_id: /mnt/models/
 
 # Path where llm-load-test has been cloned
 llm_load_test_run_src_path: projects/llm_load_test/subprojects/llm-load-test/

--- a/projects/llm_load_test/toolbox/llm_load_test_run/defaults/main/config.yml
+++ b/projects/llm_load_test/toolbox/llm_load_test_run/defaults/main/config.yml
@@ -53,3 +53,6 @@ llm_load_test_run_max_sequence_tokens: 1536
 
 # name of the endpoint to query (for openai plugin only)
 llm_load_test_run_endpoint: /v1/completions
+
+# command to use to launch Python
+llm_load_test_run_python_cmd: python3

--- a/projects/llm_load_test/toolbox/llm_load_test_run/tasks/main.yml
+++ b/projects/llm_load_test/toolbox/llm_load_test_run/tasks/main.yml
@@ -39,7 +39,14 @@
       cd "{{ llm_load_test_run_src_path }}"
       export OPENBLAS_NUM_THREADS=1 # https://github.com/OpenMathLib/OpenBLAS/wiki/Faq#how-can-i-use-openblas-in-multi-threaded-applications
 
-      time timeout $(({{ llm_load_test_run_duration }} + 25*60)) python3 load_test.py --config "{{ artifact_extra_logs_dir }}/src/llm_load_test.config.yaml" &> {{ artifact_extra_logs_dir }}/logs/run.log
+      if ! which timeout &>/dev/null; then
+        echo "no timeout on mac ..."
+        timeout=""
+      else
+        timeout="timeout $(({{ llm_load_test_run_duration }} + 25*60))"
+      fi
+
+      time $timeout {{ llm_load_test_run_python_cmd }} load_test.py --config "{{ artifact_extra_logs_dir }}/src/llm_load_test.config.yaml" &> {{ artifact_extra_logs_dir }}/logs/run.log
     register: llm_load_test_cmd
   always:
   - name: Check if llm-load-test run timed-out

--- a/projects/llm_load_test/toolbox/llm_load_test_run/tasks/main.yml
+++ b/projects/llm_load_test/toolbox/llm_load_test_run/tasks/main.yml
@@ -70,7 +70,6 @@
       set -o pipefail;
       cat {{ artifact_extra_logs_dir }}/output/output.json | jq '.summary.total_failures == .summary.total_requests'
     register: llm_load_test_no_success
-    failed_when: false
 
   - name: Fail if no request succeeded
     fail: msg="llm-load-test calls did not succeed. See logs in '{{ artifact_extra_logs_dir }}/logs/run.log'"

--- a/projects/llm_load_test/toolbox/llm_load_test_run/templates/llm-load-test-config.yaml.j2
+++ b/projects/llm_load_test/toolbox/llm_load_test_run/templates/llm-load-test-config.yaml.j2
@@ -20,12 +20,11 @@ plugin: "{{ llm_load_test_run_plugin }}"
 plugin_options:
   streaming: {{ llm_load_test_run_streaming }}
   interface: "{{ llm_load_test_run_interface }}"
+  model_name: "{{ llm_load_test_run_model_id }}"
 {% if llm_load_test_run_plugin == 'openai_plugin' %}
   host: "{{ llm_load_test_run_interface }}://{{ llm_load_test_run_host}}:{{ llm_load_test_run_port}}"
   endpoint: "{{ llm_load_test_run_endpoint }}"
-  model_name: "/mnt/models/"
 {% else %}
-  model_name: "{{ llm_load_test_run_model_id }}"
   host: "{{ llm_load_test_run_host}}"
   port: "{{ llm_load_test_run_port}}"
 {% endif %}


### PR DESCRIPTION
Relocating the llm-load-test visualization to a more logical place.

(I want to use the `llm-load-test` project outside of the `kserve` project)

/cc @mcharanrm 