### PR TITLE
[TOPSAIL] Small convenience improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .env*
 launcher/topsail_container_env
 launcher/topsail_host_config
+variable_overrides.*yaml

--- a/launcher/topsail_enter
+++ b/launcher/topsail_enter
@@ -17,6 +17,8 @@ set +a
 
 if [[ "$#" == 0 ]]; then
     command="cd $TOPSAIL_HOME && $TOPSAIL_TOOLBOX_COMMAND"
+elif [[ "$1" == "here" ]]; then
+    command="$TOPSAIL_TOOLBOX_COMMAND"
 else
     command="$@"
 fi

--- a/projects/core/library/ansible_toolbox.py
+++ b/projects/core/library/ansible_toolbox.py
@@ -131,8 +131,6 @@ class RunAnsibleRole:
         # do not modify the `os.environ` of this Python process
         env = os.environ.copy()
 
-        remote_host = env.get("TOPSAIL_JUMP_CI_REMOTE_HOST")
-
         if env.get("ARTIFACT_DIR") is None:
             topsail_base_dir = pathlib.Path(env.get("TOPSAIL_BASE_DIR", "/tmp"))
             env["ARTIFACT_DIR"] = str(topsail_base_dir / f"topsail_{time.strftime('%Y%m%d')}")
@@ -233,7 +231,9 @@ class RunAnsibleRole:
                  )
         ]
 
+        remote_host = env.get("TOPSAIL_JUMP_CI_REMOTE_HOST")
         if remote_host:
+            print(f"Using TOPSAIL_JUMP_CI_REMOTE_HOST")
             # gather only env values
             generated_play[0]["gather_facts"] = True
             generated_play[0]["gather_subset"] = ['env','!all','!min']

--- a/projects/core/library/ansible_toolbox.py
+++ b/projects/core/library/ansible_toolbox.py
@@ -272,6 +272,11 @@ class RunAnsibleRole:
                 logging.fatal(f"Could not parse file TOPSAIL_ANSIBLE_PLAYBOOK_EXTRA_VARS='{extra_vars}' as yaml ...")
                 raise
 
+            if not extra_vars_dict:
+                msg = f"TOPSAIL_ANSIBLE_PLAYBOOK_EXTRA_VARS points to an empty file :/ ({extra_vars_dict})"
+                logging.fatal(msg)
+                raise ValueError(msg)
+
             generated_play[0]["vars"] |= extra_vars_dict
 
         generated_play_path = artifact_extra_logs_dir / "_ansible.play.yaml"

--- a/projects/core/library/run.py
+++ b/projects/core/library/run.py
@@ -188,7 +188,7 @@ def run_and_catch(exc, fct, *args, **kwargs):
     if exc: raise exc
     """
     if not (exc is None or isinstance(exc, Exception)):
-        raise ValueException(f"exc={exc} should be None or an Exception")
+        raise ValueError(f"exc={exc} should be None or an Exception ({exc.__class__})")
 
     try:
         fct(*args, **kwargs)

--- a/projects/matrix_benchmarking/library/visualize.py
+++ b/projects/matrix_benchmarking/library/visualize.py
@@ -458,7 +458,7 @@ def generate_visualization(results_dirname, idx, generate_lts=None, upload_lts=N
     #
 
     if non_fatal_errors:
-        msg = f"An error happened during the visualization post-processing ... ({', '.join(non_fatal_errors)})"
+        msg = f"An error happened during the visualization post-processing ... ({', '.join(non_fatal_errors)} in {env.ARTIFACT_DIR})"
         logging.error(msg)
         with open(env.ARTIFACT_DIR / "FAILURE", "w") as f:
             print(msg, file=f)

--- a/projects/matrix_benchmarking/visualizations/helpers/store/__init__.py
+++ b/projects/matrix_benchmarking/visualizations/helpers/store/__init__.py
@@ -246,7 +246,7 @@ class _yaml_file_get():
             if missing != ...:
                 return missing
 
-            raise KeyError(f"Key '{key}' not found in {self.filename} ...")
+            raise KeyError(f"Key '{key}' not found in {self.yaml_file} ...")
 
         return match[0].value
 

--- a/variable_overrides.yaml.sample
+++ b/variable_overrides.yaml.sample
@@ -1,0 +1,7 @@
+# Sample file to help the configuration of TOPSAIL, when running locally
+# Rename it into variable_overrides.yaml for it to be taken into account
+
+ci_presets.to_apply: # put here the list of presets to apply on top of the configuration
+
+# put below the list of configuration variables to update
+# path.to.my.var: true


### PR DESCRIPTION
* `[launcher] topsail_enter: add a 'here' flag to avoid moving to topsail directory`
    *   simple helper flag that makes `topsail_enter here` behaves as `topsail_enter`

* `[matrix_benchmarking] library: visualize: show the artifact directory`
    * its convenient when running locally to see the directory where the error file is generated
* `[matrix_benchmarking] visualizations: helpers: store/__init__: improve the error fallback`
    * old typo in the code that wasn't triggered before ...
* `[core] library: config: ease the configuration of TOPSAIL for local execution`
   * first step for the rewriting of `./run_toolbox.py configure enter fine_tuning '--presets=["ilab_l40s_scale"]'` is a more convenient way (without relying on env variables ...)
* `[core] library: config: remove the code to dump the command_args.yml`
    * this was generating `command_args.yaml` from the `command_args.yaml.j2` template, each time the configuration as update. I don't think it's necessary, and it takes time to dump the file (visible when running interactively)
* `[core] library: run: run_and_catch: improve the error fallback`
    *  old typo in the code that wasn't triggered before ...
* `[core] library: ansible_toolbox: fail with a message if the extra_vars_dict is empty/None`
   * corner-case situation that I ran into. This patch assumes that if `TOPSAIL_ANSIBLE_PLAYBOOK_EXTRA_VARS` is defined but points to an empty file, that's a bug (this env var is useless if the file is empty)
