### PR TITLE
Drop hyper_parameters.skip_if from settings

### DIFF
--- a/projects/fine_tuning/visualizations/fine_tuning/store/__init__.py
+++ b/projects/fine_tuning/visualizations/fine_tuning/store/__init__.py
@@ -83,6 +83,7 @@ is_important_file = local_store.is_important_file
 def _rewrite_settings(settings_dict):
     settings_dict.pop("hyper_parameters.raw_lists", None)
     settings_dict.pop("hyper_parameters", None)
+    settings_dict.pop("hyper_parameters.skip_if", None)
 
     return settings_dict
 


### PR DESCRIPTION
To avoid visualization issues, drop `hyper_parameters.skip_if` from the settings list. 