### PR TITLE
Kserve: RHOAI 2.18.0 RC performance gating

### DIFF
--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -294,10 +294,6 @@ ci_presets:
       testing:
         size: small
         max_concurrency: 32
-    - name: mpt-7b-instruct2
-      testing:
-        size: small
-        max_concurrency: 64
     - name: llama-3-70b-instruct
       testing:
         size: large

--- a/projects/kserve/testing/config.yaml
+++ b/projects/kserve/testing/config.yaml
@@ -503,9 +503,9 @@ clusters:
 rhods:
   catalog:
     image: quay.io/rhoai/rhoai-fbc-fragment
-    tag: rhoai-2.17@sha256:d5223103d49934a96a896310c57777b149dba99c472b3574e3d6c4805d58172f
+    tag: rhoai-2.18@sha256:9cf24f4bfb33c67ca7012477de6e2f4394d54772637d16cc366effcbb52abe27
     channel: fast
-    version: 2.17.0
+    version: 2.18.0
     version_name: rc1
     opendatahub: false
     managed_rhoai: false


### PR DESCRIPTION
The email didn’t include a tag, so I used a custom tag with the valid SHA digest provided. Clients will always pull the image using the SHA digest. If a valid tag is given but the digest is invalid, clients won’t be able to download the image. 

The SHA digest is only considered when both a tag and digest are provided.