### PR TITLE
[core] library: config: resolve_references: make more reliable

### DIFF
--- a/projects/core/library/config.py
+++ b/projects/core/library/config.py
@@ -289,6 +289,10 @@ class Config:
                 logging.fatal(msg)
                 raise ValueError(msg)
 
+            if not (v.startswith("@") or "{@" in v):
+                # don't go further if the derefence anchor isn't found
+                continue
+
             if v.startswith("@"):
                 ref_key = v[1:]
                 new_value = self.get_config(ref_key)
@@ -299,8 +303,12 @@ class Config:
                     ref_value = self.get_config(ref_key, print=False)
                     new_value = new_value.replace(ref, ref_value)
 
-            self.set_config(safe_key, new_value, print=False)
-            logging.info(f"resolve_references: {k} ==> '{new_value}'")
+                logging.info(f"resolve_references: {k} ==> '{new_value}'")
+            try:
+                self.set_config(safe_key, new_value, print=False)
+            except:
+                logging.error(f"resolve_references: failed to replace '{safe_key}' ==> {new_key}")
+                raise
 
 
 def _set_config_environ(testing_dir):


### PR DESCRIPTION
* `ibm-granite/granite-3.0-8b-instruct@hf` was incorrectly detected as a config dereference

* key `ci_presets.light["tests.fine_tuning.test_settings.model_name"]` cannot be updated by `config.set_config` (because of the dots in the last field). Now writing a log message to tell we were trying to do this.