### PR TITLE
[mac_ai] testing: config: add the multi-quant flavor

### DIFF
--- a/projects/jump_ci/testing/config.yaml
+++ b/projects/jump_ci/testing/config.yaml
@@ -8,6 +8,9 @@ ci_presets:
     cluster.name: mac
     project.name: mac_ai
 
+  plot_cluster:
+    cluster.name: plot
+
 secrets:
   dir:
     name: psap-ods-secret
@@ -20,6 +23,7 @@ secrets:
 prepare:
   job_name_to_preset:
     pull-ci-openshift-psap-topsail-main-mac_ai-jump-ci: mac_ai
+    pull-ci-openshift-psap-topsail-main-jump-ci-plot: plot_cluster
 
 ssh_tunnel:
   # creates a tunnel to the bastion via the jump host, if enabled

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -74,6 +74,18 @@ ci_presets:
     - llama2
     - llama3.2
 
+  multi-quant:
+    test.model.name:
+    - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q4_K_S
+    - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q4_0
+    - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q4_K_M
+    - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q3_K_M
+    - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q5_K_S
+    prepare.platforms.to_build: null # use test.platform
+    test.platform:
+    - macos/llama_cpp/metal
+    - macos/llama_cpp/vulkan
+
   multi-users:
     test.matbenchmarking.enabled: true
     test.llm_load_test.args.concurrency: [1, 2, 4]

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -8,7 +8,7 @@ __platforms: &all_platforms
 
 ci_presets:
   # list of names of presets to apply, or a single name, or null if not preset
-  to_apply: [multi-users, llama-cpp]
+  to_apply: []
 
   # dict of variables to apply
   variable_overrides: {}

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -177,7 +177,7 @@ prepare:
           path: images/llama_cpp.containerfile
           command: /app/llama.cpp/build/bin/llama-server
           build_args:
-            LLAMA_CPP_VERSION: "@prepare.llama_cpp.repo.version"
+            LLAMA_CPP_VERSION: # set at runtime from prepare.llama_cpp.repo.version
             LLAMA_CPP_CMAKE_BUILD_FLAGS: # set at runtime with --parallel
             # ..flavors.<name> will be appended to this
             LLAMA_CPP_CMAKE_FLAGS:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CI preset named `plot_cluster` for enhanced CI operations.
  - Added support for multiple platforms in the testing configuration, including `macos/llama_cpp/metal` and `macos/llama_cpp/vulkan`.
  - Enhanced version handling for Llama CPP repository to support pull request references.
  
- **Bug Fixes**
  - Adjusted the handling of virtual users in throughput data generation to ensure consistency in metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->