### PR TITLE
[mac-ai] Allow building `llama.cpp` from a PR commit

### DIFF
--- a/docs/toolbox.generated/Remote.clone.rst
+++ b/docs/toolbox.generated/Remote.clone.rst
@@ -32,7 +32,10 @@ Parameters
 
 * The git version to clone
 
-* default value: ``main``
+
+``refspec``  
+
+* The git ref to clone. Can't be set with version
 
 
 ``force``  

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -177,7 +177,7 @@ prepare:
           path: images/llama_cpp.containerfile
           command: /app/llama.cpp/build/bin/llama-server
           build_args:
-            LLAMA_CPP_VERSION: # set at runtime from prepare.llama_cpp.repo.version
+            LLAMA_CPP_VERSION: "@prepare.llama_cpp.repo.version"
             LLAMA_CPP_CMAKE_BUILD_FLAGS: # set at runtime with --parallel
             # ..flavors.<name> will be appended to this
             LLAMA_CPP_CMAKE_FLAGS:

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -63,6 +63,11 @@ ci_presets:
     test.llm_load_test.enabled: true
     test.inference_server.benchmark.enabled: false
 
+  compare-pr:
+    prepare.llama_cpp.repo.version:
+    - b4897 # latest - 25-03-17
+    - pr_11525 # SLP: vulkan: use kompute matmul shaders on embedded GPUs #11525
+    prepare.llama_cpp.repo.url: https://github.com/kpouget/llama.cpp
   multi-version:
     prepare.llama_cpp.repo.version:
     - b4688 # slp's

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -178,6 +178,7 @@ prepare:
           command: /app/llama.cpp/build/bin/llama-server
           build_args:
             LLAMA_CPP_VERSION: "@prepare.llama_cpp.repo.version"
+            LLAMA_CPP_REPO: "@prepare.llama_cpp.repo.url"
             LLAMA_CPP_CMAKE_BUILD_FLAGS: # set at runtime with --parallel
             # ..flavors.<name> will be appended to this
             LLAMA_CPP_CMAKE_FLAGS:

--- a/projects/mac_ai/testing/images/llama_cpp.containerfile
+++ b/projects/mac_ai/testing/images/llama_cpp.containerfile
@@ -15,18 +15,24 @@ RUN dnf install -y python3-dnf-plugin-versionlock && \
 
 WORKDIR /app/llama.cpp
 
+ARG LLAMA_CPP_REPO="https://github.com/ggml-org/llama.cpp"
 ARG LLAMA_CPP_VERSION="b4735"
 ARG LLAMA_CPP_CMAKE_FLAGS="-DGGML_VULKAN=ON  -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=native"
 ARG LLAMA_CPP_CMAKE_BUILD_FLAGS="--parallel 4"
 
-RUN git clone https://github.com/ggml-org/llama.cpp src -b ${LLAMA_CPP_VERSION}
-RUN mkdir build
-RUN git -C src submodule update --init ggml/src/ggml-kompute/kompute
+RUN git clone "${LLAMA_CPP_REPO}" src \
+ && git -C src fetch origin ${LLAMA_CPP_VERSION} \
+ && git -C src reset --hard FETCH_HEAD \
+ && git -C src submodule update --init ggml/src/ggml-kompute/kompute
 
-RUN mkdir -p ../build && echo "Build flags: $LLAMA_CPP_CMAKE_FLAGS" > ../build/build.flags.log
-RUN cd src && set -o pipefail && \
-    cmake -S . -B ../build ${LLAMA_CPP_CMAKE_FLAGS} | tee ../build/build.prepare.log && \
-    cmake --build ../build/ ${LLAMA_CPP_CMAKE_BUILD_FLAGS} | tee ../build/build.compile.log
+RUN mkdir -p build \
+ && echo "Version: ${LLAMA_CPP_VERSION}" > build/build.flags.log \
+ && echo "cmake flags: $LLAMA_CPP_CMAKE_FLAGS" >> build/build.flags.log \
+ && echo "Build flags: $LLAMA_CPP_CMAKE_BUILD_FLAGS" >> build/build.flags.log \
+ && cd src \
+ && set -o pipefail \
+ && cmake -S . -B ../build ${LLAMA_CPP_CMAKE_FLAGS} | tee ../build/build.prepare.log \
+ && cmake --build ../build/ ${LLAMA_CPP_CMAKE_BUILD_FLAGS} | tee ../build/build.compile.log
 
 # ---
 

--- a/projects/mac_ai/testing/prepare_llama_cpp.py
+++ b/projects/mac_ai/testing/prepare_llama_cpp.py
@@ -109,15 +109,7 @@ def prepare_podman_image_from_local_container_file(base_work_dir, platform):
     build_args["LLAMA_CPP_CMAKE_FLAGS"] = cmake_flags
     build_args["LLAMA_CPP_CMAKE_BUILD_FLAGS"] = cmake_build_flags
 
-    version = config.project.get_config("prepare.llama_cpp.repo.version")
-    if version.startswith("pr-"):
-        pr_number = version.removeprefix("pr-")
-        git_version = f"refs/pull/{pr_number}/head"
-    else:
-        git_version = version
-
-
-    build_args["LLAMA_CPP_VERSION"] = git_version
+    build_args["LLAMA_CPP_VERSION"] =  config.project.resolve_reference(build_args["LLAMA_CPP_VERSION"])
 
     artifact_dir_suffix = "_" + "_".join([pathlib.Path(container_file).name, inference_server_flavor])
 
@@ -209,15 +201,9 @@ def prepare_from_source(base_work_dir, platform):
     if not remote_access.exists(dest):
         repo_url = config.project.get_config("prepare.llama_cpp.repo.url")
 
-        if version.startswith("pr-"):
-            pr_number = version.removeprefix("pr-")
-            git_version = f"refs/pull/{pr_number}/head"
-        else:
-            git_version = version
-
         run.run_toolbox(
             "remote", "clone",
-            repo_url=repo_url, dest=dest, version=git_version,
+            repo_url=repo_url, dest=dest, version=version,
             artifact_dir_suffix="_llama_cpp",
         )
 

--- a/projects/mac_ai/testing/prepare_llama_cpp.py
+++ b/projects/mac_ai/testing/prepare_llama_cpp.py
@@ -109,7 +109,12 @@ def prepare_podman_image_from_local_container_file(base_work_dir, platform):
     build_args["LLAMA_CPP_CMAKE_FLAGS"] = cmake_flags
     build_args["LLAMA_CPP_CMAKE_BUILD_FLAGS"] = cmake_build_flags
 
-    build_args["LLAMA_CPP_VERSION"] =  config.project.resolve_reference(build_args["LLAMA_CPP_VERSION"])
+    build_args["LLAMA_CPP_REPO"] = config.project.resolve_reference(build_args["LLAMA_CPP_REPO"])
+    version = build_args["LLAMA_CPP_VERSION"] = config.project.resolve_reference(build_args["LLAMA_CPP_VERSION"])
+
+    if version.startswith("pr-"):
+        pr_number = version.removeprefix("pr-")
+        build_args["LLAMA_CPP_VERSION"] = f"refs/pull/{pr_number}/head"
 
     artifact_dir_suffix = "_" + "_".join([pathlib.Path(container_file).name, inference_server_flavor])
 
@@ -170,12 +175,12 @@ def prepare_from_binary(base_work_dir, platform):
     if not tarball:
         raise ValueError("llama_cpp on MacOS/Darwin should be a tarball :/")
 
-    llama_cpp_path, dest, platform_file = _get_binary_path(base_work_dir, platform)
+    llama_cpp_path, dest, platform_file, version = _get_binary_path(base_work_dir, platform)
 
     source = "/".join([
         config.project.get_config("prepare.llama_cpp.repo.url"),
         "releases/download",
-        config.project.get_config("prepare.llama_cpp.repo.version"),
+        version,
         platform_file,
     ])
 
@@ -196,22 +201,39 @@ def prepare_from_binary(base_work_dir, platform):
 def prepare_from_source(base_work_dir, platform):
     version = config.project.get_config("prepare.llama_cpp.repo.version")
 
-    dest = base_work_dir / "llama_cpp" / f"llama.cpp-tags-{version}"
+    dirname = "llama.cpp-"
+    if version.startswith("pr-"):
+        dirname += version
+    else:
+        dirname += f"tag-{version}"
+
+    dest = base_work_dir / "llama_cpp" / dirname
 
     if not remote_access.exists(dest):
         repo_url = config.project.get_config("prepare.llama_cpp.repo.url")
 
+        kwargs = dict(
+            repo_url=repo_url,
+            dest=dest,
+        )
+
+        if version.startswith("pr-"):
+            pr_number = version.removeprefix("pr-")
+            kwargs["refspec"] = f"refs/pull/{pr_number}/head"
+        else:
+            kwargs["version"] = version
+
         run.run_toolbox(
             "remote", "clone",
-            repo_url=repo_url, dest=dest, version=version,
+            **kwargs,
             artifact_dir_suffix="_llama_cpp",
         )
 
         # for the Kompute build
-        cmd = f"sed -i.bu s/-Werror//g llama_cpp/llama.cpp-tags-{version}/ggml/src/ggml-kompute/kompute/CMakeLists.txt"
+        cmd = f"sed -i.bu s/-Werror//g {dest}/ggml/src/ggml-kompute/kompute/CMakeLists.txt"
         remote_access.run_with_ansible_ssh_conf(base_work_dir, cmd)
 
-    src_dir = dest.parent / f"llama.cpp-tags-{version}"
+    src_dir = dest
     cmake_parallel = config.project.get_config("prepare.llama_cpp.repo.source.cmake.parallel")
 
     if not platform.inference_server_flavor:
@@ -317,19 +339,25 @@ def _get_binary_path(base_work_dir, platform):
         container_command = config.project.get_config("prepare.llama_cpp.repo.podman.command")
         command = f"{podman_prefix} {container_command}"
 
-        return command, None, None
+        return command, None, None, None
 
     version = config.project.get_config("prepare.llama_cpp.repo.version", print=False)
 
     if not utils.check_expected_platform(platform, system="macos", inference_server_name="llama_cpp", inference_server_flavor="upstream_bin"):
         file_name = config.project.get_config("prepare.llama_cpp.repo.darwin.upstream_bin.file")
+
+        if True: #version.startswith("pr-"):
+            VERSION = "b4897"
+            logging.info(f"Version {version} is a PR. Using hardcoded version {VERSION} for downloading the upstream binary.")
+            version = VERSION
+
         dest = base_work_dir / "llama_cpp" / f"release-{platform.system}-{version}" / file_name
         llama_cpp_path = dest.parent / "build" / "bin" / "llama-server"
 
-        return llama_cpp_path, dest, file_name
+        return llama_cpp_path, dest, file_name, version
     elif platform.system == "macos":
         llama_cpp_path = base_work_dir / "llama_cpp" / f"build-{platform.name.replace('/', '-')}-{version}" / "bin" / "llama-server"
-        return llama_cpp_path, None, None
+        return llama_cpp_path, None, None, version
     else:
         pass
 
@@ -337,7 +365,7 @@ def _get_binary_path(base_work_dir, platform):
 
 
 def get_binary_path(base_work_dir, platform):
-    llama_cpp_path, _, _ = _get_binary_path(base_work_dir, platform)
+    llama_cpp_path, _, _, _ = _get_binary_path(base_work_dir, platform)
     return llama_cpp_path
 
 

--- a/projects/mac_ai/toolbox/mac_ai_remote_capture_power_usage/tasks/main.yml
+++ b/projects/mac_ai/toolbox/mac_ai_remote_capture_power_usage/tasks/main.yml
@@ -5,8 +5,13 @@
     state: directory
     mode: '0755'
 
+- name: Set the name of the exit file
+  set_fact:
+    exit_file: /tmp/exit_topsail_power_usage_capture
+
 - name: Ensure that there is no other sampler running
-  command:
+  shell: |
+    touch {{ exit_file }}
     sudo pkill powermetrics
   failed_when: false
 
@@ -14,17 +19,22 @@
   meta: end_play
   when: mac_ai_remote_capture_power_usage_stop | bool
 
+- name: Give a bit of time for the previous samples command to terminate
+  command:
+    sleep 5 # give time to exit to the previous samplers ...
+
 - name: Start capturing the power usage
   shell: |
-    nohup sudo powermetrics \
-         --samplers {{ mac_ai_remote_capture_power_usage_samplers }} \
-         --sample-rate {{ mac_ai_remote_capture_power_usage_sample_rate }} \
-         &> "{{ artifact_extra_logs_dir }}/artifacts/power_usage.txt" &
-
-    pid=$!;
-    sleep 5; # give nohup time to start
-    echo Running with PID=$pid;
-    ps ux -p "$pid"
-    echo "---"
-    head "{{ artifact_extra_logs_dir }}/artifacts/power_usage.txt"
-    echo "---"
+    rm -f {{ exit_file }}
+    nohup bash > "{{ artifact_extra_logs_dir }}/artifacts/power_usage.txt"  -c '
+      while true; do
+        sudo powermetrics \
+          --samplers {{ mac_ai_remote_capture_power_usage_samplers }} \
+          --sample-rate {{ mac_ai_remote_capture_power_usage_sample_rate }} \
+          --sample-count 10;
+        sleep 1;
+        if [[ -e "{{ exit_file }}" ]]; then
+          echo Exiting.
+          exit 0
+        fi
+      done' &

--- a/projects/remote/toolbox/remote.py
+++ b/projects/remote/toolbox/remote.py
@@ -17,7 +17,8 @@ class Remote:
             self,
             repo_url,
             dest,
-            version="main",
+            version=None,
+            refspec=None,
             force=False
     ):
         """
@@ -27,8 +28,12 @@ class Remote:
           repo_url: the URL of the repo to clone
           dest: the directory where the repo should be cloned
           version: the git version to clone
+          refspec: the git ref to clone. Can't be set with version
           force: force the git clone
         """
+
+        if version and refspec:
+            raise ValueError(f"--version={version} and --refspec={refspec} can't be pass together")
 
         return RunAnsibleRole(locals())
 

--- a/projects/remote/toolbox/remote_clone/defaults/main/config.yml
+++ b/projects/remote/toolbox/remote_clone/defaults/main/config.yml
@@ -12,7 +12,10 @@ remote_clone_repo_url:
 remote_clone_dest:
 
 # the git version to clone
-remote_clone_version: main
+remote_clone_version: null
+
+# the git ref to clone. Can't be set with version
+remote_clone_refspec: null
 
 # force the git clone
 remote_clone_force: false

--- a/projects/remote/toolbox/remote_clone/tasks/main.yaml
+++ b/projects/remote/toolbox/remote_clone/tasks/main.yaml
@@ -7,12 +7,22 @@
 
 - name: Execute the remote clone
   block:
-  - name: Git checkout
+  - name: Git checkout by refspec
+    ansible.builtin.git:
+      repo: '{{ remote_clone_repo_url }}'
+      dest: "{{ remote_clone_dest }}"
+      refspec: "{{ remote_clone_refspec }}"
+      force: "{{ remote_clone_force }}"
+    when: remote_clone_refspec or '' | length
+
+   # noqa latest[git]
+  - name: Git checkout by version
     ansible.builtin.git:
       repo: '{{ remote_clone_repo_url }}'
       dest: "{{ remote_clone_dest }}"
       version: "{{ remote_clone_version }}"
       force: "{{ remote_clone_force }}"
+    when: remote_clone_version or '' | length
 
   - name: Show the commit of the version that has been cloned
     shell:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The CI process now dynamically selects the appropriate repository version during builds, ensuring that both stable releases and pull request builds are handled seamlessly.
  - Added a new parameter `refspec` for more precise control over Git operations during remote cloning.
  - Introduced a task for Git checkout based on a reference specification in the remote clone process.
  - A new variable `exit_file` has been added to manage the termination of the power usage capture process.
  - Enhanced the handling of versioning and directory naming conventions for improved clarity.

- **Bug Fixes**
  - Validation added to prevent simultaneous use of `version` and `refspec` parameters in the cloning process.

- **Refactor**
  - The version resolution logic has been updated to distinguish between standard versions and pull request identifiers, resulting in a more flexible and reliable build configuration.
  - Updated the clone method to allow for either a version or a refspec, enhancing flexibility and preventing ambiguous cloning instructions.
  - Enhanced the logic for starting and stopping the power metrics collection process for improved control.
  - Restructured the Dockerfile commands for improved flow and organization during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->