### PR TITLE
docs: requirements: fix dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx-rtd-theme==1.3.0
-myst-parser==4.0.1
+myst-parser
 sphinxcontrib-versioning==2.2.1


### PR DESCRIPTION
```
The conflict is caused by:
    sphinx-rtd-theme 1.3.0 depends on docutils<0.19
    myst-parser 4.0.1 depends on docutils<0.22 and >=0.19
```