### PR TITLE
[core] library: config: correctly order the config saved in SHARED_DIR

### DIFF
--- a/projects/core/library/config.py
+++ b/projects/core/library/config.py
@@ -168,7 +168,7 @@ class Config:
         if (shared_dir := os.environ.get("SHARED_DIR")) and (shared_dir_path := pathlib.Path(shared_dir)) and shared_dir_path.exists():
 
             with open(shared_dir_path / "config.yaml", "w") as f:
-                yaml.dump(self.config, f, indent=4)
+                yaml.dump(self.config, f, indent=4, default_flow_style=False, sort_keys=False)
 
     def save_config_overrides(self):
         variable_overrides_path = env.ARTIFACT_DIR / VARIABLE_OVERRIDES_FILENAME


### PR DESCRIPTION
example of an expected config:
```
preset[mac_ai] secrets.dir.name --> crc-mac-ai-secret
preset[mac_ai] secrets.dir.env_key --> CRC_MAC_AI_SECRET_PATH
preset[mac_ai] cluster.name --> mac
preset[mac_ai] project.name --> mac_ai
preset[mac_ai_nightly] project.args --> ['cpt_nightly']
preset[mac_ai_nightly] cluster.name --> mac5
```

and a wrong one
```
preset[mac_ai_nightly] cluster.name --> mac5
preset[mac_ai] cluster.name --> mac
preset[mac_ai] project.name --> mac_ai
preset[mac_ai] secrets.dir.env_key --> CRC_MAC_AI_SECRET_PATH
preset[mac_ai] secrets.dir.name --> crc-mac-ai-secret
preset[mac_ai_nightly] project.args --> ['cpt_nightly']
```

caused by the alphabetic ordering of this dictionnary:
```
  mac_ai_nightly:
    extends: [mac_ai]
    project.args: [cpt_nightly]
    cluster.name: mac5
```