### PR TITLE
[mac-ai] Update Ramalama usage of `--image`

### DIFF
--- a/projects/mac_ai/testing/prepare_release.py
+++ b/projects/mac_ai/testing/prepare_release.py
@@ -207,7 +207,7 @@ Try it
 * run ramalama with our custom image.
 ```
 export CONTAINERS_MACHINE_PROVIDER=libkrun
-ramalama --image {ramalama_image} run llama3.2
+ramalama run --image {ramalama_image} llama3.2
 ```
 
 """)
@@ -291,7 +291,7 @@ Benchmarking
 
 * API Remoting Performance
 ```
-ramalama --image {ramalama_image} bench  llama3.2 # benchmarking mode
+ramalama bench --image {ramalama_image} llama3.2 # benchmarking mode
 ```
 
 * Native Performance

--- a/projects/mac_ai/toolbox/mac_ai_remote_ramalama_run_bench/tasks/main.yml
+++ b/projects/mac_ai/toolbox/mac_ai_remote_ramalama_run_bench/tasks/main.yml
@@ -10,8 +10,8 @@
     export {{ mac_ai_remote_ramalama_run_bench_env }}
 
     {{ mac_ai_remote_ramalama_run_bench_path }} \
-       --image {{ mac_ai_remote_ramalama_run_bench_image }} \
        bench \
+       --image {{ mac_ai_remote_ramalama_run_bench_image }} \
         {{ mac_ai_remote_ramalama_run_bench_model_name }} \
         --ngl {{ mac_ai_remote_ramalama_run_bench_ngl }} \
     {% if mac_ai_remote_ramalama_run_bench_device -%}

--- a/projects/mac_ai/toolbox/mac_ai_remote_ramalama_run_model/tasks/main.yml
+++ b/projects/mac_ai/toolbox/mac_ai_remote_ramalama_run_model/tasks/main.yml
@@ -28,8 +28,8 @@
       export {{ mac_ai_remote_ramalama_run_model_env }}
       nohup {{ mac_ai_remote_ramalama_run_model_path }} \
          --debug \
-         --image {{ mac_ai_remote_ramalama_run_model_image }} \
          serve \
+         --image {{ mac_ai_remote_ramalama_run_model_image }} \
          {{ mac_ai_remote_ramalama_run_model_model_name }} \
          --ngl {{ mac_ai_remote_ramalama_run_model_ngl }} \
          --port {{ mac_ai_remote_ramalama_run_model_port }} \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples in documentation to reflect the correct position of the --image option in ramalama command-line instructions.

* **Chores**
  * Adjusted command-line invocation order in task configurations to place the --image option after the subcommand for consistency with updated usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->