### PR TITLE
[mac_ai] Add the ability to publish the Podman Desktop extension image

### DIFF
--- a/docs/toolbox.generated/Remote.retrieve.rst
+++ b/docs/toolbox.generated/Remote.retrieve.rst
@@ -27,3 +27,8 @@ Parameters
 
 * The location where to save the files
 
+
+``push_mode``  
+
+* If enabled, push to the remote system instead of pulling
+

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -94,8 +94,8 @@ ci_presets:
   remoting_publish:
     extends: [remoting]
     prepare.remoting.publish: true
-    prepare.llama_cpp.source.repo.version: b5709-remoting-0.1.4
-    prepare.virglrenderer.repo.branch: v1.1.1-remoting-0.1.3
+    prepare.llama_cpp.source.repo.version: b5709-remoting-0.1.5
+    prepare.virglrenderer.repo.branch: v1.1.1-remoting-0.1.4
     prepare.ramalama.build_image.enabled: true
     prepare.ramalama.build_image.publish.enabled: true
     prepare.ramalama.build_image.registry_path: quay.io/crcont

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -101,7 +101,7 @@ ci_presets:
     prepare.ramalama.build_image.registry_path: quay.io/crcont
     prepare.ramalama.build_image.name: remoting
     prepare.ramalama.repo.url: https://github.com/kpouget/ramalama
-    prepare.ramalama.repo.version: v0.10.0-remoting-0.2.1
+    prepare.ramalama.repo.version: v0.11.2-remoting-0.2.1
     prepare.remoting.podman_desktop_extension.enabled: true
     prepare.remoting.podman_desktop_extension.image.publish.enabled: true
 

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -109,7 +109,7 @@ ci_presets:
     - podman/ramalama/remoting
     - podman/llama_cpp/remoting
     - macos/llama_cpp/metal
-    - podman/llama_cpp/vulkan
+    - macos/llama_cpp/vulkan
 
   debug:
     prepare.llama_cpp.source.cmake.debug.enabled: true

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -102,6 +102,8 @@ ci_presets:
     prepare.ramalama.build_image.name: remoting
     prepare.ramalama.repo.url: https://github.com/kpouget/ramalama
     prepare.ramalama.repo.version: v0.10.0-remoting-0.2.1
+    prepare.remoting.podman_desktop_extension.enabled: true
+    prepare.remoting.podman_desktop_extension.image.publish.enabled: true
 
     test.platform:
     - podman/ramalama/remoting
@@ -402,6 +404,18 @@ prepare:
           APIR_LLAMA_CPP_GGML_LIBRARY_INIT: ggml_backend_metal_init
 
   remoting:
+    podman_desktop_extension:
+      enabled: false
+      repo:
+        url: https://github.com/crc-org/podman-desktop-remoting-ext
+        version: main
+      image:
+        containerfile: Containerfile
+        dest: quay.io/crcont/podman-desktop-remoting-ext
+        publish:
+          enabled: false
+          credentials: "*$@secrets.image_registry"
+
     publish: false
 
 test:

--- a/projects/mac_ai/testing/prepare_release.py
+++ b/projects/mac_ai/testing/prepare_release.py
@@ -94,6 +94,8 @@ def build_remoting_tarball(base_work_dir, package_libs):
     src_info_dir = tarball_dir / "src_info"
     src_info_dir.mkdir()
 
+    add_string_file(src_info_dir / "version.txt", llama_cpp_url + "\n")
+
     virglrenderer_src_dir = prepare_virglrenderer.get_build_dir(base_work_dir) / ".." / "src"
     virglrenderer_git_rev = add_remote_git_status(base_work_dir, virglrenderer_src_dir,
                                                   src_info_dir / "virglrenderer.git-commit.txt")

--- a/projects/mac_ai/testing/prepare_release.py
+++ b/projects/mac_ai/testing/prepare_release.py
@@ -117,6 +117,9 @@ def build_remoting_tarball(base_work_dir, package_libs):
     krunkit_script_file = pathlib.Path("projects/mac_ai/testing/scripts/update_krunkit.sh")
     add_local_file(krunkit_script_file, tarball_dir / krunkit_script_file.name)
 
+    check_podman_machine_script_file = pathlib.Path("projects/mac_ai/testing/scripts/check_podman_machine_status.sh")
+    add_local_file(check_podman_machine_script_file, tarball_dir / check_podman_machine_script_file.name)
+
     import prepare_mac_ai
     ramalama_image = ramalama.get_release_image_name(base_work_dir, prepare_mac_ai.RAMALAMA_REMOTING_PLATFORM)
 

--- a/projects/mac_ai/testing/remote_access.py
+++ b/projects/mac_ai/testing/remote_access.py
@@ -138,7 +138,7 @@ set -o errtrace
 
 {chdir_cmd}
 
-exec {cmd}
+{cmd}
     """
 
     if config.project.get_config("remote_host.verbose_ssh_commands", print=False) and not handled_secretly:

--- a/projects/mac_ai/testing/scripts/check_podman_machine_status.sh
+++ b/projects/mac_ai/testing/scripts/check_podman_machine_status.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+set -o errtrace
+
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+version=$(cat "$SCRIPT_DIR/src_info/version.txt")
+
+if [[ -z "$version" ]]; then
+  echo "Couldn't find the API Remoting version identifier :/"
+  exit 20
+fi
+
+# don't fail on this one ;-)
+LSOF_VIRGL=$((lsof -c krunkit || true) | (grep virglrenderer || true))
+
+if [[ "$LSOF_VIRGL" == *"$version"* ]]; then
+  echo "krunkit running with API Remoting support"
+  exit 0
+elif [[ "$LSOF_VIRGL" == *"krunkit"* ]]; then
+  echo "krunkit running WITHOUT API Remoting support"
+  exit 11
+else
+  echo "krunkit not running"
+  exit 12
+fi

--- a/projects/mac_ai/testing/scripts/check_podman_machine_status.sh
+++ b/projects/mac_ai/testing/scripts/check_podman_machine_status.sh
@@ -15,7 +15,7 @@ if [[ -z "$version" ]]; then
 fi
 
 # don't fail on this one ;-)
-LSOF_VIRGL=$((lsof -c krunkit || true) | (grep virglrenderer || true))
+LSOF_VIRGL=$(lsof -c krunkit || true | grep virglrenderer || true)
 
 if [[ "$LSOF_VIRGL" == *"$version"* ]]; then
   echo "krunkit running with API Remoting support"

--- a/projects/mac_ai/testing/scripts/check_podman_machine_status.sh
+++ b/projects/mac_ai/testing/scripts/check_podman_machine_status.sh
@@ -1,5 +1,13 @@
 #! /bin/bash
 
+# checks the status of the Podman Machine for API Remoting
+# return values:
+#  0 ==> running with API Remoting support
+# 10 ==> running vfkit VM instead of krunkit
+# 11 ==> krunkit not running
+# 12 ==> krunkit running without API Remoting
+# 2x ==> script cannot run correctly
+
 set -o pipefail
 set -o errexit
 set -o nounset
@@ -14,16 +22,28 @@ if [[ -z "$version" ]]; then
   exit 20
 fi
 
-# don't fail on this one ;-)
-LSOF_VIRGL=$(lsof -c krunkit || true | grep virglrenderer || true)
-
-if [[ "$LSOF_VIRGL" == *"$version"* ]]; then
-  echo "krunkit running with API Remoting support"
-  exit 0
-elif [[ "$LSOF_VIRGL" == *"krunkit"* ]]; then
-  echo "krunkit running WITHOUT API Remoting support"
-  exit 11
-else
-  echo "krunkit not running"
-  exit 12
+if lsof -c vfkit > /dev/null; then
+    echo "PodMan Machine running with VFKit (not compatible with the API Remoting support)"
+    exit 10
 fi
+
+lsof_virgl=$(lsof -c krunkit || true | grep virglrenderer || true)
+
+if [[ -z "$lsof_virgl" ]]; then
+    echo "krunkit not running"
+    exit 11
+fi
+
+# using the version identifier to test the API Remoting support:
+#
+# if the version identifier is found, then we assume that the right
+# krunkit/libkrun/libvirglrenderer are running.
+
+if [[ "$lsof_virgl" != *"$version"* ]]; then
+    echo "krunkit running WITHOUT API Remoting support"
+    exit 12
+fi
+
+echo "krunkit running with API Remoting support"
+
+exit 0

--- a/projects/mac_ai/testing/scripts/update_krunkit.sh
+++ b/projects/mac_ai/testing/scripts/update_krunkit.sh
@@ -108,14 +108,19 @@ main() {
         sleep 2
     fi
 
-    macos_version_major=$(sw_vers --productVersion | cut -d. -f1)
-    if [[ "$macos_version_major" != "$SUPPORTED_MAC_OS_VERSION" ]]; then
-        echo "WARNING: this tarball only supports MAC OS $SUPPORTED_MAC_OS_VERSION"
-        echo
-        sleep 2
+    if ! command -v sw_vers >/dev/null 2>&1; then
+        echo "WARNING: API Remoting only supported on MacOS. 'sw_vers' command missing ..."
+
+    else
+        macos_version_major=$(sw_vers --productVersion | cut -d. -f1)
+        if [[ "$macos_version_major" != "$SUPPORTED_MAC_OS_VERSION" ]]; then
+            echo "WARNING: this tarball only supports MacOS $SUPPORTED_MAC_OS_VERSION"
+            echo
+            sleep 2
+        fi
     fi
 
-    krunkit_path=$(which krunkit)
+    krunkit_path=$(command -v krunkit 2>/dev/null || true)
 
     if [[ -z "$krunkit_path" ]]; then
         echo "ERROR: krunkit not available ..."

--- a/projects/remote/toolbox/remote.py
+++ b/projects/remote/toolbox/remote.py
@@ -68,6 +68,7 @@ class Remote:
             self,
             path,
             dest,
+            push_mode=False,
     ):
         """
         Retrieves remote files locally
@@ -75,6 +76,7 @@ class Remote:
         Args:
           path: the location of the files in the remote system
           dest: the location where to save the files
+          push_mode: if enabled, push to the remote system instead of pulling
         """
 
         return RunAnsibleRole(locals())

--- a/projects/remote/toolbox/remote_retrieve/defaults/main/config.yml
+++ b/projects/remote/toolbox/remote_retrieve/defaults/main/config.yml
@@ -10,3 +10,6 @@ remote_retrieve_path:
 # the location where to save the files
 # Mandatory value
 remote_retrieve_dest:
+
+# if enabled, push to the remote system instead of pulling
+remote_retrieve_push_mode: false

--- a/projects/remote/toolbox/remote_retrieve/tasks/main.yaml
+++ b/projects/remote/toolbox/remote_retrieve/tasks/main.yaml
@@ -2,12 +2,18 @@
 - name: Get the size of the directory to retrieve
   command:
     du -sh "{{ remote_retrieve_path }}"
+  when: not remote_retrieve_push_mode
+
+- name: Ensure that the remote directory exists
+  command:
+    mkdir -p  "{{ remote_retrieve_dest }}"
+  when: remote_retrieve_push_mode
 
 - name: Copy all the files locally
   ansible.posix.synchronize:
     src: "{{ remote_retrieve_path }}/"
     dest: "{{ remote_retrieve_dest }}"
-    mode: "pull"
+    mode: "{% if remote_retrieve_push_mode %}push{% else %}pull{% endif %}"
     recursive: true
     owner: false
     perms: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for building and optionally publishing a Podman Desktop extension container image during release preparation.
  * Introduced configuration options to enable and customize the Podman Desktop extension build and image publishing.
  * Included a new script to verify the running status and API Remoting support of the "krunkit" process.
  * Added a new option to control file synchronization direction, enabling pushing files to remote systems.

* **Chores**
  * Enhanced version tracking in release artifacts by adding a version file.
  * Updated documentation to clarify the behavior of the new synchronization parameter.
  * Improved macOS version check and command detection in the update script.
  * Adjusted remote command execution to improve shell handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->