### PR TITLE
[mac_ai] testing: config: cpt_all: don't build podman/llama_cpp/vulkan for now

### DIFF
--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -58,7 +58,7 @@ ci_presets:
     test.platform:
     - podman/ramalama
     - macos/llama_cpp/vulkan
-    - podman/llama_cpp/vulkan
+    # - podman/llama_cpp/vulkan
     - macos/llama_cpp/metal
 
   cpt_ramalama:


### PR DESCRIPTION
…

image doesn't build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI test presets by disabling one platform from the active matrix.
  * Preserved coverage on remaining platforms; test behavior for supported environments remains unchanged.
  * No impact on features, performance, or user workflows.
  * Build and release outputs remain the same.
  * No documentation updates required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->