### PR TITLE
[mac_ai] testing: ramalama: conditionally set LLAMA_CPP env vars for remoting builds

### DIFF
--- a/projects/mac_ai/testing/ramalama.py
+++ b/projects/mac_ai/testing/ramalama.py
@@ -88,9 +88,11 @@ def build_container_image(base_work_dir, ramalama_path):
 
         extra_env = dict(
             REGISTRY_PATH=registry_path,
-            LLAMA_CPP_PULL_REF=config.project.get_config("prepare.llama_cpp.source.repo.version"),
-            LLAMA_CPP_REPO=config.project.get_config("prepare.llama_cpp.source.repo.url"),
         )
+
+        if config.project.get_config("prepare.ramalama.build_image.name") == "remoting":
+            extra_env["LLAMA_CPP_PULL_REF"] = config.project.get_config("prepare.llama_cpp.source.repo.version")
+            extra_env["LLAMA_CPP_REPO"] = config.project.get_config("prepare.llama_cpp.source.repo.url")
 
         if config.project.get_config("prepare.ramalama.build_image.debug"):
             extra_env["RAMALAMA_IMAGE_BUILD_DEBUG"] = "y"


### PR DESCRIPTION
Only set `LLAMA_CPP_PULL_REF` and `LLAMA_CPP_REPO` environment variables when the build image name is "remoting" to avoid unnecessary configuration for other build types.

🤖 Generated with (a tiny bit of help of) [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted container image build environment: LLAMA_CPP_PULL_REF and LLAMA_CPP_REPO are now set only for remoting builds. REGISTRY_PATH remains included, and debug flag handling is unchanged.
  - Impact: Remoting builds behave as before; non-remoting builds omit these variables, reducing unintended llama.cpp configuration in other build types.
  - No user-facing interface changes; builds should be more predictable without additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->