### PR TITLE
[mac-ai] Test with multiple models

### DIFF
--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -176,6 +176,7 @@ ci_presets:
     - b5076 # latest - 25-04-08
 
   multi-models:
+    test.matbenchmarking.enabled: true
     test.model.name:
     - granite3.3
     - qwen
@@ -186,6 +187,7 @@ ci_presets:
     - gpt-oss
 
   multi-model-sizes:
+    test.matbenchmarking.enabled: true
     test.model.name:
     - ollama://llama3.2:1b
     - ollama://llama3.2:3b
@@ -193,6 +195,7 @@ ci_presets:
     - ollama://llama2:13b
 
   multi-quant:
+    test.matbenchmarking.enabled: true
     test.model.name:
     - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q4_K_S
     - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q4_0

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -95,6 +95,7 @@ ci_presets:
     prepare.ramalama.build_image.name: remoting
     prepare.ramalama.repo.url: https://github.com/kpouget/ramalama
     prepare.ramalama.repo.version: v0.12.0-apir.rc3
+    prepare.remoting.podman_desktop_extension.repo.version: v0.1.2
 
     test.platform:
     - podman/ramalama/remoting
@@ -418,7 +419,7 @@ prepare:
       enabled: false
       repo:
         url: https://github.com/crc-org/podman-desktop-remoting-ext
-        version: v0.1.1
+        version: v0.1.2
       image:
         containerfile: Containerfile
         dest: quay.io/crcont/podman-desktop-remoting-ext

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -177,12 +177,13 @@ ci_presets:
 
   multi-models:
     test.model.name:
-    - hf://ibm-granite/granite-8b-code-base-4k-GGUF/granite-8b-code-base.Q4_K_M.gguf
-    - hf://ggml-org/gemma-3-4b-it-GGUF
-    - hf://instructlab/merlinite-7b-lab-GGUF/merlinite-7b-lab-Q4_K_M.gguf
-    - hf://MaziyarPanahi/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf
-    - hf://ggml-org/Qwen2.5-VL-7B-Instruct-GGUF
-    - hf://TheBloke/Llama-2-7B-Chat-GGUF:Q4_K_M
+    - granite3.3
+    - qwen
+    - phi
+    - llama3.2
+    - mistral
+    - gemma3
+    - gpt-oss
 
   multi-model-sizes:
     test.model.name:

--- a/projects/mac_ai/testing/prepare_release.py
+++ b/projects/mac_ai/testing/prepare_release.py
@@ -387,7 +387,7 @@ def prepare_podman_desktop_extension_image(base_work_dir, tarball_dir, build_ver
     # update the version number
     package_content = remote_access.run_with_ansible_ssh_conf(base_work_dir, "cat package.json", chdir=ext_repo_dest, capture_stdout=True)
     package_json_content = json.loads(package_content.stdout)
-    ext_version = package_json_content["version"]
+    ext_version = config.project.get_config("prepare.remoting.podman_desktop_extension.repo.version")
     package_json_content["version"] = f"{ext_version}+{build_version}"
     write_package_json_cmd = f"""cat > package.json <<EOF
 {json.dumps(package_json_content, indent=4)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enabled matbenchmarking across additional CI presets (multi-models, multi-model-sizes, multi-quant).
  - Added a multi-users benchmarking preset with configurable concurrency (1, 2, 4).

- Tests
  - Updated multi-models test set to include granite3.3, qwen, phi, llama3.2, mistral, gemma3, and gpt-oss.
  - Activated benchmarking in multi-model-sizes and multi-quant.

- Chores
  - Bumped podman-desktop extension version to v0.1.2 and switched extension version sourcing to configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->