### PR TITLE
[mac-ai] Add the `lightspeed` test platform

### DIFF
--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -52,6 +52,9 @@ ci_presets:
   cpt_nightly:
     extends: [cpt_all, mac5]
 
+  cpt_nightly_lightspeed:
+    extends: [cpt_lightspeed, mac5]
+
   cpt_all:
     extends: [cpt_ramalama, cpt_llama_cpp]
     test.model.name: ollama://llama3.2
@@ -82,6 +85,11 @@ ci_presets:
     prepare.llama_cpp.source.repo.version: latest
     matbench.lts.generate: true
     test.inference_server.benchmark.enabled: true
+
+  cpt_lightspeed:
+    extends: [lightspeed, use_intlab_os, analyze_kpis, export_kpis]
+    test.llm_load_test.args.concurrency: 1
+    test.llm_load_test.args.duration: 300
 
   # ---
 
@@ -128,6 +136,16 @@ ci_presets:
     - podman/llama_cpp/remoting
     - macos/llama_cpp/metal
     - podman/llama_cpp/vulkan
+
+  # ---
+
+  lightspeed:
+    test.platform: podman/lightspeed
+    test.model.name: /models/Phi-4-mini-instruct-Q4_K_M.gguf
+    test.inference_server.port: 8888
+    test.inference_server.benchmark.enabled: true
+    test.matbenchmarking.enabled: false
+    test.llm_load_test.enabled: true
 
   llama_cpp:
     test.platform:
@@ -261,12 +279,18 @@ prepare:
       llama_cpp: macos/llama_cpp/upstream_bin
       ollama: macos/ollama
       ramalama: podman/ramalama
+      lightspeed: podman/lightspeed
 
   cleanup_on_exit: false
   prepare_only_inference_server: false
 
   llm_load_test:
     install_requirements: false
+
+  lightspeed:
+    installer:
+      image: quay.io/redhat-user-workloads/rhel-lightspeed-tenant/installer
+      version: latest
 
   llama_cpp:
     iterable_build_fields: # sync with test.matbenchmarking.iterable_test_fields if necessary
@@ -507,9 +531,11 @@ cleanup:
     llm-load-test: true
     podman: true
     virglrenderer: true
+    lightspeed: true
 
   images:
     llama_cpp: true
+    lightspeed: true
 
   podman_machine:
     delete: true
@@ -560,7 +586,7 @@ exec_list:
 
 __platform_check:
   system: [macos, podman]
-  inference_server: [llama_cpp, ollama, ramalama]
+  inference_server: [llama_cpp, ollama, ramalama, lightspeed]
 
   options:
     no_gpu: no-gpu

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -173,7 +173,6 @@ ci_presets:
 
   benchmark:
     extends: [bench_only]
-    test.matbenchmarking.enabled: true
 
     test.llm_load_test.args.concurrency: 1
     test.llm_load_test.args.duration: 300

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -250,7 +250,7 @@ remote_host:
   env:
     PATH: "/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
   home_is_base_work_dir: true
-  verbose_ssh_commands: true
+  verbose_ssh_commands: false
 
 prepare:
   # the list of platform environments to prepare

--- a/projects/mac_ai/testing/lightspeed.py
+++ b/projects/mac_ai/testing/lightspeed.py
@@ -1,0 +1,137 @@
+import os
+import pathlib
+import logging
+import tempfile
+import json
+
+from projects.core.library import env, config, run, configure_logging, export
+from projects.matrix_benchmarking.library import visualize
+
+import podman as podman_mod
+import remote_access, utils
+
+
+def prepare_test(base_work_dir, platform):
+    # nothing to do here
+    pass
+
+
+def prepare_binary(base_work_dir, platform):
+    installer_image(base_work_dir, pull=True)
+
+    remote_access.run_with_ansible_ssh_conf(base_work_dir, f"rm -rf '{base_work_dir}/.config/rhel-lightspeed'")
+
+    bin_dir = installer_run(base_work_dir, "install")
+
+    podman_cmd = podman_mod.get_podman_command()
+
+    # /!\ podzman typo is on purpose to avoid sed to rewrite podman multiple times (over multiple executions)
+    remote_access.write(bin_dir / "podzman", f'#!/usr/bin/env bash\n{podman_cmd} "\$@"\n')
+    remote_access.run_with_ansible_ssh_conf(base_work_dir, f"chmod u+x '{bin_dir / 'podzman'}'")
+
+    remote_access.run_with_ansible_ssh_conf(base_work_dir, f"sed 's+podman+{bin_dir / 'podzman'}+g' '{base_work_dir}/.config/rhel-lightspeed/rhel-lightspeed-runner.sh' > '{base_work_dir}/.config/rhel-lightspeed/rhel-lightspeed-runner.new.sh'")
+    remote_access.run_with_ansible_ssh_conf(base_work_dir, f"mv '{base_work_dir}/.config/rhel-lightspeed/rhel-lightspeed-runner.new.sh' '{base_work_dir}/.config/rhel-lightspeed/rhel-lightspeed-runner.sh'")
+
+    return bin_dir / "rhel-lightspeed"
+
+
+def get_binary_path(base_work_dir, platform):
+    return base_work_dir / ".local" / "bin" / "rhel-lightspeed"
+
+
+def installer_image(base_work_dir, pull=False, rm=False):
+    image_name = get_image_name()
+    if not podman_mod.has_image(base_work_dir, image_name):
+        if pull:
+            podman_mod.pull_image(base_work_dir, image_name)
+            return True
+        return False
+    else:
+        if rm:
+            podman_mod.rm_image(base_work_dir, image_name)
+            return False
+        return True
+
+
+def installer_run(base_work_dir, command):
+    base_dir = base_work_dir
+
+    config_dir = base_dir / ".config"
+    remote_access.mkdir(config_dir)
+
+    bin_dir = base_dir / ".local/bin"
+    remote_access.mkdir(bin_dir)
+
+    volumes = {
+        str(config_dir): "/config",
+        str(bin_dir): "/config/.local/bin",
+    }
+
+    podman_mod.run_container(base_work_dir, get_image_name(), volumes=volumes, command=command)
+
+    return bin_dir
+
+
+def has_model(base_work_dir, lightspeed_path, model_name):
+    return True
+
+
+def pull_model(base_work_dir, lightspeed_path, model_name):
+    if not model_name.startswith("/models/"):
+        raise ValueError("Lightspeed can only be tested with the lightspeed model")
+
+    logging.info("Nothing to do ...")
+
+    return
+
+
+def start_server(base_work_dir, lightspeed_path):
+    with env.NextArtifactDir("lightspeed_start_server"):
+        inspect = podman_mod.inspect_image(base_work_dir, get_image_name())
+        with open(env.ARTIFACT_DIR / "inspect-image.json", "w") as f:
+            json.dump(inspect, indent=4, fp=f)
+
+        remote_access.run_with_ansible_ssh_conf(base_work_dir, f"bash {lightspeed_path} start")
+
+
+def stop_server(base_work_dir, lightspeed_path):
+    remote_access.run_with_ansible_ssh_conf(base_work_dir, f"bash {lightspeed_path} stop")
+
+
+def run_model(base_work_dir, platform, lightspeed_path, model):
+    pass # nothing to do
+
+
+def unload_model(base_work_dir, platform, lightspeed_path, model):
+    pass # nothing to do
+
+
+def run_benchmark(base_work_dir, platform, lightspeed_path, model):
+    with env.NextArtifactDir("lightspeed_run_bench"):
+        remote_access.mkdir(env.ARTIFACT_DIR / "artifacts")
+        remote_access.run_with_ansible_ssh_conf(base_work_dir,
+                                                      f"{podman_mod.get_podman_command()} exec llamacpp-model llama-bench --verbose -m '{model}' > '{env.ARTIFACT_DIR}/artifacts/llama-bench.log' 2>&1")
+
+    pass
+
+
+def cleanup_files(base_work_dir):
+    installer_image(base_work_dir, rm=True)
+
+    remote_access.run_with_ansible_ssh_conf(
+        base_work_dir, f"rm -rf '{base_work_dir}/.config/rhel-lightspeed'"
+    )
+    remote_access.run_with_ansible_ssh_conf(
+        base_work_dir, f"rm -f '{base_work_dir}/.local/bin/rhel-lightspeed' '{base_work_dir}/.local/bin/podzman'"
+    )
+
+
+def cleanup_images(base_work_dir):
+    podman_mod.rm_image(base_work_dir, get_image_name())
+
+
+def get_image_name():
+    image = config.project.get_config("prepare.lightspeed.installer.image")
+    version = config.project.get_config("prepare.lightspeed.installer.version")
+
+    return f"{image}:{version}"

--- a/projects/mac_ai/testing/podman.py
+++ b/projects/mac_ai/testing/podman.py
@@ -146,6 +146,16 @@ def has_image(base_work_dir, image):
     return ret.returncode == 0
 
 
+def pull_image(base_work_dir, image):
+    podman_cmd = get_podman_command()
+
+    ret = remote_access.run_with_ansible_ssh_conf(
+        base_work_dir,
+        f"{podman_cmd} image pull {image}",
+    )
+
+    return ret.returncode == 0
+
 def rm_image(base_work_dir, image):
     podman_cmd = get_podman_command()
 
@@ -158,6 +168,19 @@ def rm_image(base_work_dir, image):
     )
 
     return ret.returncode == 0
+
+
+def run_container(base_work_dir, image, volumes=None, user=":", command=""):
+    podman_cmd = get_podman_command()
+
+    volumes_str = ''
+    if volumes:
+        volumes_str = " ".join([f"-v '{key}:{value}:Z'" for key, value in volumes.items()])
+
+    remote_access.run_with_ansible_ssh_conf(
+        base_work_dir,
+        f"{podman_cmd} run --user '{user}' --pull=never --rm {volumes_str} '{image}' {command}",
+    )
 
 
 def start(base_work_dir, port):

--- a/projects/mac_ai/testing/podman.py
+++ b/projects/mac_ai/testing/podman.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import logging
 import yaml
+import json
 
 from projects.core.library import env, config, run, configure_logging, export
 import remote_access, utils
@@ -155,6 +156,21 @@ def pull_image(base_work_dir, image):
     )
 
     return ret.returncode == 0
+
+
+def inspect_image(base_work_dir, image):
+    podman_cmd = get_podman_command()
+
+    ret = remote_access.run_with_ansible_ssh_conf(
+        base_work_dir,
+        f"{podman_cmd} image inspect {image}",
+        check=True,
+        capture_stdout=True,
+        capture_stderr=True,
+    )
+
+    return json.loads(ret.stdout)
+
 
 def rm_image(base_work_dir, image):
     podman_cmd = get_podman_command()

--- a/projects/mac_ai/testing/podman.py
+++ b/projects/mac_ai/testing/podman.py
@@ -21,7 +21,6 @@ def cleanup(base_work_dir):
 
 
 def prepare_gv_from_gh_binary(base_work_dir):
-
     podman_path, version = _get_repo_podman_path(base_work_dir)
     gvisor_path = podman_path.parent.parent / "libexec" / "podman" / "gvproxy"
 
@@ -43,6 +42,7 @@ def prepare_gv_from_gh_binary(base_work_dir):
         source=source,
         dest=gvisor_path,
         executable=True,
+        artifact_dir_suffix="__gvproxy",
     )
 
 def prepare_from_gh_binary(base_work_dir):
@@ -71,6 +71,7 @@ def prepare_from_gh_binary(base_work_dir):
         source=source,
         dest=dest,
         zip=True,
+        artifact_dir_suffix="__podman",
     )
 
     return podman_path

--- a/projects/mac_ai/testing/prepare_llama_cpp.py
+++ b/projects/mac_ai/testing/prepare_llama_cpp.py
@@ -383,6 +383,8 @@ def cleanup_image(base_work_dir):
 
     for platform_str in platforms_to_build_str:
         platform = utils.parse_platform(platform_str)
+        if platform.inference_server_name != "llama_cpp": continue
+
         if not platform.needs_podman: continue
 
         prepare_test(base_work_dir, platform)

--- a/projects/mac_ai/testing/prepare_mac_ai.py
+++ b/projects/mac_ai/testing/prepare_mac_ai.py
@@ -6,7 +6,7 @@ from projects.core.library import env, config, run, configure_logging, export
 from projects.matrix_benchmarking.library import visualize
 
 import utils, remote_access, podman_machine, brew, podman, prepare_virglrenderer, prepare_release
-import prepare_llama_cpp, llama_cpp, ollama, ramalama
+import prepare_llama_cpp, llama_cpp, ollama, ramalama, lightspeed
 
 TESTING_THIS_DIR = pathlib.Path(__file__).absolute().parent
 CRC_MAC_AI_SECRET_PATH = pathlib.Path(os.environ.get("CRC_MAC_AI_SECRET_PATH", "/env/CRC_MAC_AI_SECRET_PATH/not_set"))
@@ -15,12 +15,14 @@ PREPARE_INFERENCE_SERVERS = dict(
     llama_cpp=prepare_llama_cpp,
     ollama=ollama,
     ramalama=ramalama,
+    lightspeed=lightspeed,
 )
 
 INFERENCE_SERVERS = dict(
     llama_cpp=llama_cpp,
     ollama=ollama,
     ramalama=ramalama,
+    lightspeed=lightspeed,
 )
 
 
@@ -69,6 +71,12 @@ def cleanup():
 
     if config.project.get_config("cleanup.files.ramalama"):
         ramalama.cleanup_files(base_work_dir)
+
+    if config.project.get_config("cleanup.files.lightspeed"):
+        lightspeed.cleanup_files(base_work_dir)
+
+    if config.project.get_config("cleanup.images.lightspeed"):
+        lightspeed.cleanup_images(base_work_dir)
 
     # ***
 

--- a/projects/mac_ai/testing/remote_access.py
+++ b/projects/mac_ai/testing/remote_access.py
@@ -88,7 +88,7 @@ def run_with_ansible_ssh_conf(
         capture_stderr=False,
         chdir=None,
         print_cmd=False,
-        handled_secretly=True,
+        handled_secretly=False,
         decode_stdout=True,
         decode_stderr=True,
 ):
@@ -149,6 +149,7 @@ set -o errtrace
 
     with open(tmp_file_path, "w") as f:
         print(entrypoint_script, file=f)
+
     if print_cmd:
         print(entrypoint_script)
 

--- a/projects/mac_ai/testing/utils.py
+++ b/projects/mac_ai/testing/utils.py
@@ -43,7 +43,7 @@ def parse_platform(platform_str):
         raise ValueError(f"Invalid platform inference server '{platform.inference_server_name}' in {platform_str}. Expected one of {expected_servers}")
 
     # too complex to put in the configuration file!
-    if platform.inference_server_name == "ramalama":
+    if platform.inference_server_name in ("ramalama", "lightspeed"):
         platform.needs_podman_machine = True
         platform.needs_podman= False
     else:


### PR DESCRIPTION
Reviewed-by-AI: CodeRabbit, Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Lightspeed inference-server support: installer, Podman-based lifecycle, remote start/stop, benchmarking, and artifact capture; CI presets for Lightspeed runs.

- **Tests**
  - Added end-to-end Lightspeed testing, benchmarking workflows, remoting presets, and a nightly Lightspeed CI preset.

- **Chores**
  - Enabled Lightspeed image/file cleanup and added cleanup/config entries.

- **Improvements**
  - Added Podman remote utilities, extended platform parsing and result parsers to include Lightspeed, and changed default SSH-run verbosity to be more verbose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->