### PR TITLE
[mac-ai] Update to support llama.cpp foreign testing

### DIFF
--- a/projects/jump_ci/testing/config.yaml
+++ b/projects/jump_ci/testing/config.yaml
@@ -63,6 +63,13 @@ cluster:
 project:
   name: null
   args: null
+
+foreign_testing: # used only when testing from another repo that TOPSAIL itself
+  topsail:
+    repo:
+      owner: openshift-psap
+      name: topsail
+      branch: main
 ssh:
   flags:
   - -oStrictHostKeyChecking=no
@@ -72,7 +79,7 @@ env:
   pass_lists:
     OPENSHIFT_CI_job: [JOB_TYPE, ENTRYPOINT_OPTIONS, JOB_NAME, JOB_SPEC, OPENSHIFT_CI, JOB_NAME_SAFE, BUILD_ID]
     OPENSHIFT_CI_git_pr: [PULL_PULL_SHA, PULL_NUMBER, PULL_BASE_REF, REPO_NAME, REPO_OWNER, PULL_BASE_SHA, JOB_NAME, PULL_TITLE, PULL_REFS, PULL_HEAD_REF]
-    OPENSHIFT_CI_topsail: [TOPSAIL_OPENSHIFT_CI_STEP_DIR]
+    OPENSHIFT_CI_topsail: [TOPSAIL_OPENSHIFT_CI_STEP_DIR, OPENSHIFT_CI_TOPSAIL_FOREIGN_TESTING]
 
 rewrite_variables_overrides:
   cluster_found_in_pr_args: false

--- a/projects/jump_ci/testing/config.yaml
+++ b/projects/jump_ci/testing/config.yaml
@@ -29,7 +29,7 @@ ci_presets:
   llama_cpp_presubmit:
     secrets.dir.name: crc-mac-ai-secret # key/value never actually used
     secrets.dir.env_key: CRC_MAC_AI_SECRET_PATH
-    cluster.name: mac
+    cluster.name: mac5
     project.name: mac_ai
 
   plot_cluster:

--- a/projects/jump_ci/toolbox/jump_ci_prepare_topsail/tasks/main.yml
+++ b/projects/jump_ci/toolbox/jump_ci_prepare_topsail/tasks/main.yml
@@ -159,7 +159,7 @@
     ENTRYPOINT []
     CMD []
 
-    RUN git fetch --quiet origin {{ git_ref }}
+    RUN git fetch --quiet origin "{{ git_commit_cmd.stdout }}"
     RUN git reset --hard FETCH_HEAD
     RUN git submodule --quiet update --init --recursive --force
     RUN git submodule

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -129,7 +129,7 @@ ci_presets:
     prepare.llama_cpp.source.repo.version: main
     test.platform:
     - podman/llama_cpp/remoting
-    - macos/llama_cpp/vulkan
+    - macos/llama_cpp/metal
 
   remoting_publish:
     extends: [remoting, use_intlab_os]

--- a/projects/mac_ai/testing/config.yaml
+++ b/projects/mac_ai/testing/config.yaml
@@ -291,6 +291,16 @@ remote_host:
   verbose_ssh_commands: false
   description: null
 
+foreign_testing:
+  llama_cpp:
+    repo: prepare.llama_cpp.source.repo.url
+    version: prepare.llama_cpp.source.repo.version
+    presets:
+    - remoting_wip
+  ramalama:
+    repo: prepare.ramalama.repo.url
+    version: prepare.ramalama.repo.version
+
 prepare:
   # the list of platform environments to prepare
   platforms:

--- a/projects/repo/toolbox/notifications/github/api.py
+++ b/projects/repo/toolbox/notifications/github/api.py
@@ -24,7 +24,12 @@ def get_user_token(pem_file, client_id, org, repo):
 
     installation_resp = requests.get(f"{BASE_URL}/repos/{org}/{repo}/installation", headers=headers)
 
-    installation_id = installation_resp.json()["id"]
+    try:
+        installation_id = installation_resp.json()["id"]
+    except Exception as e:
+        msg = f"Failed to get the user token: {e}"
+        logging.error(msg)
+        raise e
 
     # Get the user token
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pyjwt
 slack_sdk==3.35.0
 setuptools
 pandas
-opensearchpy
+opensearch-py

--- a/testing/utils/openshift_ci/pr_args.sh
+++ b/testing/utils/openshift_ci/pr_args.sh
@@ -33,7 +33,7 @@ if [[ "${TEST_NAME:-}" ]]; then
     test_name="$TEST_NAME"
 
 elif [[ "${OPENSHIFT_CI:-}" == true ]]; then
-    JOB_NAME_PREFIX=pull-ci-${REPO_OWNER}-${REPO_NAME}-${PULL_BASE_REF}
+    JOB_NAME_PREFIX=pull-ci-${REPO_OWNER}-${REPO_NAME}-main
     test_name=$(echo "$JOB_NAME" | sed "s/$JOB_NAME_PREFIX-//")
 
     if [[ "${TOPSAIL_LOCAL_CI:-}" == true ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enable “foreign testing” to run against external repositories via an opt-in environment variable.
  - Add SHA-based version support for llama.cpp builds and sources.
  - Switch macOS llama.cpp tests from Vulkan to Metal.

- Bug Fixes
  - Improve error handling when retrieving GitHub installation tokens.
  - More resilient cleanup and quieter, safer SSH connections.

- Chores
  - Update OpenSearch client dependency package name.
  - Adjust OpenShift CI test-name parsing to a stable “-main” prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->