### PR TITLE
[crc-timing]: toolbox: timing_refresh_image: new command to update an AWS AMI image

### DIFF
--- a/docs/toolbox.generated/Crc.refresh_image.rst
+++ b/docs/toolbox.generated/Crc.refresh_image.rst
@@ -1,0 +1,91 @@
+:orphan:
+
+..
+    _Auto-generated file, do not edit manually ...
+    _Toolbox generate command: repo generate_toolbox_rst_documentation
+    _ Source component: Crc.refresh_image
+
+
+crc refresh_image
+=================
+
+Update a CRC AMI image with a given SNC repo commit
+
+
+
+
+Parameters
+----------
+
+
+``source_snapshot_id``  
+
+* The source Snapshot ID (e.g., snap-0123...)
+
+
+``new_ami_name``  
+
+* The name for the new AMI
+
+
+``key_pair_name``  
+
+* An existing EC2 Key Pair name for the worker instance
+
+
+``private_key_path``  
+
+* Path to the private key to use to login into the controller EC2
+
+
+``git_repo``  
+
+* The URL of the repo to use for updating the SNC image
+
+
+``git_branch``  
+
+* The repo branch to use for updating the SNC image
+
+
+``aws_region``  
+
+* The region to use
+
+* default value: ``us-west-1``
+
+
+``aws_availability_zone``  
+
+* The availability zone to use
+
+* default value: ``us-west-1a``
+
+
+``worker_instance_type``  
+
+* The instance type for the controller EC2
+
+* default value: ``t2.micro``
+
+
+``worker_ami_id``  
+
+* The AMI ID to run on the controller EC2
+
+* default value: ``ami-0020037e76c9ad658``
+
+
+``security_group_name``  
+
+* The name of the security-group to use. Date will be added
+
+* default value: ``topsail-refresh-image-sg``
+
+
+``ami_image_user``  
+
+* The name of the user to use in the image
+
+* default value: ``fedora``
+

--- a/docs/toolbox.generated/index.rst
+++ b/docs/toolbox.generated/index.rst
@@ -60,6 +60,17 @@ Toolbox Documentation
 * :doc:`image_build_large_build_context_benchmark <Container_Bench.image_build_large_build_context_benchmark>`	 Runs the image build large build context benchmark with the given runtime
 * :doc:`prepare_benchmark_script_on_remote <Container_Bench.prepare_benchmark_script_on_remote>`	 Prepares the benchmark script on the remote machine
 
+``crc``
+*******
+
+::
+
+    Commands relating to CRC
+    
+
+                
+* :doc:`refresh_image <Crc.refresh_image>`	 Update a CRC AMI image with a given SNC repo commit
+
 ``fine_tuning``
 ***************
 

--- a/projects/crc-timing/toolbox/crc.py
+++ b/projects/crc-timing/toolbox/crc.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import logging
+
+from projects.core.library.ansible_toolbox import (
+    RunAnsibleRole, AnsibleRole,
+    AnsibleMappedParams, AnsibleConstant,
+    AnsibleSkipConfigGeneration
+)
+
+class Crc:
+    """
+    Commands relating to CRC
+    """
+
+    @AnsibleRole("crc_timing_refresh_image")
+    @AnsibleMappedParams
+    def refresh_image(
+            self,
+            source_snapshot_id,
+            new_ami_name,
+            key_pair_name,
+            private_key_path,
+            git_repo,
+            git_branch,
+            aws_region="us-west-1",
+            aws_availability_zone="us-west-1a",
+            worker_instance_type="t2.micro",
+            worker_ami_id="ami-0020037e76c9ad658", # Fedora-Cloud-Base-AmazonEC2.x86_64-42-Prerelease-202504
+            security_group_name="topsail-refresh-image-sg",
+            ami_image_user="fedora",
+    ):
+        """
+        Update a CRC AMI image with a given SNC repo commit
+
+        Args:
+            source_snapshot_id: the source Snapshot ID (e.g., snap-0123...)
+            new_ami_name: the name for the new AMI
+            key_pair_name: an existing EC2 Key Pair name for the worker instance
+            private_key_path: path to the private key to use to login into the controller EC2
+            git_repo: the URL of the repo to use for updating the SNC image
+            git_branch: the repo branch to use for updating the SNC image
+
+            aws_region: the region to use
+            aws_availability_zone: the availability zone to use
+            worker_instance_type: the instance type for the controller EC2
+            worker_ami_id: the AMI ID to run on the controller EC2
+            security_group_name: the name of the security-group to use. Date will be added
+            ami_image_user: the name of the user to use in the image
+        """
+
+        return RunAnsibleRole(locals())

--- a/projects/crc-timing/toolbox/crc_timing_refresh_image/defaults/main/config.yml
+++ b/projects/crc-timing/toolbox/crc_timing_refresh_image/defaults/main/config.yml
@@ -1,0 +1,46 @@
+# Auto-generated file, do not edit manually ...
+# Toolbox generate command: repo generate_ansible_default_settings
+# Source component: Crc.refresh_image
+
+# Parameters
+# the source Snapshot ID (e.g., snap-0123...)
+# Mandatory value
+crc_timing_refresh_image_source_snapshot_id:
+
+# the name for the new AMI
+# Mandatory value
+crc_timing_refresh_image_new_ami_name:
+
+# an existing EC2 Key Pair name for the worker instance
+# Mandatory value
+crc_timing_refresh_image_key_pair_name:
+
+# path to the private key to use to login into the controller EC2
+# Mandatory value
+crc_timing_refresh_image_private_key_path:
+
+# the URL of the repo to use for updating the SNC image
+# Mandatory value
+crc_timing_refresh_image_git_repo:
+
+# the repo branch to use for updating the SNC image
+# Mandatory value
+crc_timing_refresh_image_git_branch:
+
+# the region to use
+crc_timing_refresh_image_aws_region: us-west-1
+
+# the availability zone to use
+crc_timing_refresh_image_aws_availability_zone: us-west-1a
+
+# the instance type for the controller EC2
+crc_timing_refresh_image_worker_instance_type: t2.micro
+
+# the AMI ID to run on the controller EC2
+crc_timing_refresh_image_worker_ami_id: ami-0020037e76c9ad658
+
+# the name of the security-group to use. Date will be added
+crc_timing_refresh_image_security_group_name: topsail-refresh-image-sg
+
+# the name of the user to use in the image
+crc_timing_refresh_image_ami_image_user: fedora

--- a/projects/crc-timing/toolbox/crc_timing_refresh_image/meta/main.yml
+++ b/projects/crc-timing/toolbox/crc_timing_refresh_image/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/projects/crc-timing/toolbox/crc_timing_refresh_image/tasks/main.yml
+++ b/projects/crc-timing/toolbox/crc_timing_refresh_image/tasks/main.yml
@@ -1,0 +1,275 @@
+---
+- name: Create the src directory
+  file:
+    path: "{{ artifact_extra_logs_dir }}/src"
+    state: directory
+    mode: '0755'
+
+- name: Create the artifacts directory
+  file:
+    path: "{{ artifact_extra_logs_dir }}/artifacts"
+    state: directory
+    mode: '0755'
+
+- name: Main execution block with cleanup
+  block:
+  - name: Set the security-group-name
+    set_fact:
+      security_group_name: "{{  crc_timing_refresh_image_security_group_name }}-{{ lookup('pipe', 'date +%s') }}"
+
+
+  - name: Create Security Group for SSH access
+    command:
+      aws ec2 create-security-group
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --group-name "{{ security_group_name }}"
+          --description "Allow SSH for TOPSAIL to access the EC2 instance"
+    register: sg_create_raw
+
+  - name: Set Security Group ID fact
+    set_fact:
+      security_group_id: "{{ (sg_create_raw.stdout | from_json).GroupId }}"
+
+  - name: Authorize SSH ingress to the Security Group
+    command:
+      aws ec2 authorize-security-group-ingress
+            --region "{{ crc_timing_refresh_image_aws_region }}"
+            --group-id "{{ security_group_id }}"
+            --protocol tcp
+            --port 22
+            --cidr 0.0.0.0/0
+
+
+  - name: 1. Get snapshot details (AZ and Size)
+    command:
+        aws ec2 describe-snapshots
+            --region "{{ crc_timing_refresh_image_aws_region }}"
+            --snapshot-ids "{{ crc_timing_refresh_image_source_snapshot_id }}"
+            --query "Snapshots[0].{Size:VolumeSize}"
+    register: snapshot_details_raw
+
+  - name: Set snapshot facts
+    set_fact:
+      snapshot_size: "{{ (snapshot_details_raw.stdout | from_json).Size }}"
+
+  - name: Print snapshot details
+    debug:
+      msg: "Found snapshot with size '{{ snapshot_size }} GiB'."
+
+  - name: 2. Create EBS volume from snapshot
+    command:
+      aws ec2 create-volume
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --snapshot-id "{{ crc_timing_refresh_image_source_snapshot_id }}"
+          --availability-zone "{{ crc_timing_refresh_image_aws_availability_zone }}"
+    register: volume_create_raw
+
+  - name: Set volume ID fact
+    set_fact:
+      volume_id: "{{ (volume_create_raw.stdout | from_json).VolumeId }}"
+
+  - name: Set volume blck ID fact
+    set_fact:
+      volume_blk_id: "{{ volume_id.replace('vol-', '') }}"
+
+  - name: Wait for volume to become available
+    command:
+      aws ec2 wait volume-available
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --volume-ids "{{ volume_id }}"
+    changed_when: false
+
+  - name: Apply the instance script template
+    template:
+      src: "{{ instance_script_template }}"
+      dest: "{{ artifact_extra_logs_dir }}/src/instance_script.sh"
+      mode: '0700'
+
+  - name: 3. Launch temporary worker instance
+    command:
+        aws ec2 run-instances
+            --region "{{ crc_timing_refresh_image_aws_region }}"
+            --image-id "{{ crc_timing_refresh_image_worker_ami_id }}"
+            --instance-type "{{ crc_timing_refresh_image_worker_instance_type }}"
+            --key-name "{{ crc_timing_refresh_image_key_pair_name }}"
+            --placement "AvailabilityZone={{ crc_timing_refresh_image_aws_availability_zone }}"
+            --security-group-ids "{{ security_group_id }}"
+    no_log: true # too verbose
+    register: instance_create_raw
+
+  - name: Set instance ID fact
+    set_fact:
+      instance_id: "{{ (instance_create_raw.stdout | from_json).Instances[0].InstanceId }}"
+
+  - name: Print info about EC2 instance being created
+    debug:
+      msg: Created EC2 instance {{ instance_id }}
+
+  - name: Wait for instance to be running
+    command:
+      time aws ec2 wait instance-running
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --instance-ids "{{ instance_id }}"
+    changed_when: false
+
+  - name: Get the Public IP of the instance
+    command:
+      aws ec2 describe-instances
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --instance-ids "{{ instance_id}}"
+          --query "Reservations[0].Instances[0].PublicIpAddress"
+          --output text
+    register: ec2_public_ip_cmd
+
+  - name: 4. Attach volume to worker instance
+    command:
+      aws ec2 attach-volume
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --device /dev/sdf
+          --instance-id "{{ instance_id }}"
+          --volume-id "{{ volume_id }}"
+
+  - name: Print info about EC2 instance public IP
+    debug:
+      msg: "Ec2 instance IP: {{ ec2_public_ip_cmd.stdout }}"
+
+  - name: Set the ssh parameters
+    set_fact:
+      ssh_args: '-oIdentitiesOnly=yes -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "{{ crc_timing_refresh_image_private_key_path }}"'
+      ssh_host: "{{ crc_timing_refresh_image_ami_image_user }}@{{ ec2_public_ip_cmd.stdout }}"
+
+  - name: Wait for the SSH connection to work
+    command:
+      ssh {{ ssh_args }} {{ ssh_host }} exit 0
+    retries: 30
+    delay: 5
+    register: ssh_working
+    until: ssh_working.rc == 0
+
+  - name: Copy the script to the remote host
+    command:
+      scp {{ ssh_args }} "{{ artifact_extra_logs_dir }}/src/instance_script.sh" {{ ssh_host }}:instance_script.sh
+
+  - name: Execute the script on the remote host
+    command:
+      ssh  {{ ssh_args }} {{ ssh_host }} bash -x instance_script.sh
+
+  - name: 5. Detach volume from worker
+    command:
+      aws ec2 detach-volume
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --instance-id "{{ instance_id }}"
+          --volume-id "{{ volume_id }}"
+
+  - name: Wait for volume to become available again
+    command:
+      aws ec2 wait volume-available
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --volume-ids "{{ volume_id }}"
+    changed_when: false
+
+  - name: 6. Create new snapshot from modified volume
+    command:
+      aws ec2 create-snapshot
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --volume-id "{{ volume_id }}"
+          --description "Snapshot for new AMI {{ crc_timing_refresh_image_new_ami_name }}"
+    register: new_snapshot_raw
+
+  - name: Set new snapshot ID fact
+    set_fact:
+      new_snapshot_id: "{{ (new_snapshot_raw.stdout | from_json).SnapshotId }}"
+
+  - name: Wait for new snapshot to complete
+    command:
+      aws ec2 wait snapshot-completed
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --snapshot-ids "{{ new_snapshot_id }}"
+    changed_when: false
+
+  - name: 7. Check for existing AMI and deregister it
+    block:
+    - name: Find AMI by name
+      command:
+        aws ec2 describe-images
+            --region "{{ crc_timing_refresh_image_aws_region }}"
+            --owners self
+            --filters "Name=name,Values={{ crc_timing_refresh_image_new_ami_name }}"
+            --query "Images[0].{ImageId:ImageId, SnapshotId:BlockDeviceMappings[0].Ebs.SnapshotId}"
+      register: existing_ami_raw
+      changed_when: false
+
+  - name: Set existing AMI facts
+    set_fact:
+      existing_ami: "{{ existing_ami_raw.stdout | from_json }}"
+    when: existing_ami_raw.stdout | from_json is not none
+
+  - name: Deregister the old AMI if it exists
+    when: existing_ami is defined and existing_ami.ImageId
+    block:
+    - name: Print info about AMI being deleted
+      debug:
+        msg: "Found existing AMI {{ existing_ami.ImageId }} with snapshot {{ existing_ami.SnapshotId }}. Deregistering it now."
+
+    - name: Deregister AMI
+      command:
+        aws ec2 deregister-image
+            --region "{{ crc_timing_refresh_image_aws_region }}"
+            --image-id {{ existing_ami.ImageId }}
+
+    - name: Delete associated snapshot
+      command:
+        aws ec2 delete-snapshot
+            --region "{{ crc_timing_refresh_image_aws_region }}"
+            --snapshot-id "{{ existing_ami.SnapshotId }}"
+
+  - name: 8. Register new AMI from the snapshot
+    command: |
+      aws ec2 register-image \
+          --region "{{ crc_timing_refresh_image_aws_region }}" \
+          --name "{{ crc_timing_refresh_image_new_ami_name }}" \
+          --description "Custom AMI created by Ansible from snapshot {{ crc_timing_refresh_image_source_snapshot_id }}" \
+          --architecture x86_64 \
+          --root-device-name /dev/sda1 \
+          --block-device-mappings '[{"DeviceName": "/dev/sda1", "Ebs": {"SnapshotId": "{{ new_snapshot_id }}", "VolumeType": "gp2", "DeleteOnTermination": true}}]' \
+          --virtualization-type hvm \
+          --ena-support
+    register: new_ami_raw
+
+  - name: Set new AMI ID fact
+    set_fact:
+      new_ami_id: "{{ (new_ami_raw.stdout | from_json).ImageId }}"
+
+  always:
+  - name: Cleanup. Terminate worker instance
+    command:
+      aws ec2 terminate-instances
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --instance-ids "{{ instance_id }}"
+    when: instance_id is defined
+
+  - name: Wait for worker instance to be fully terminated
+    command:
+      aws ec2 wait instance-terminated
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --instance-ids "{{ instance_id }}"
+    when: instance_id is defined
+    changed_when: false
+
+  - name: Cleanup. Delete intermediate volume
+    command:
+      aws ec2 delete-volume
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --volume-id "{{ volume_id }}"
+    when: volume_id is defined
+
+  - name: Cleanup. Delete the temporary Security Group
+    command:
+      aws ec2 delete-security-group
+          --region "{{ crc_timing_refresh_image_aws_region }}"
+          --group-id {{ security_group_id }}
+    when: security_group_id is defined
+
+- name: Print success message
+  debug:
+    msg: "SUCCESS! New AMI created: {{ new_ami_id }}"

--- a/projects/crc-timing/toolbox/crc_timing_refresh_image/templates/instance_script.sh.j2
+++ b/projects/crc-timing/toolbox/crc_timing_refresh_image/templates/instance_script.sh.j2
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+set -o errtrace
+
+echo "--- Starting User Data Script ---"
+
+DEVICE_NAME=xvdf4
+
+MOUNT_POINT="/mnt/"
+echo "Device identified as /dev/${DEVICE_NAME}"
+mkdir -p ${MOUNT_POINT}
+sudo mount /dev/${DEVICE_NAME} ${MOUNT_POINT}
+
+
+echo "--- Filesystem mounted ---"
+
+sudo dnf install -y git > /dev/null
+
+ROOT_FS=$(echo $MOUNT_POINT/ostree/deploy/rhcos/deploy/*.0)
+
+# --- !!! YOUR MODIFICATIONS GO HERE !!! ---
+
+cd /tmp
+git clone "{{ crc_timing_refresh_image_git_repo }}" -b "{{ crc_timing_refresh_image_git_branch }}"
+cd snc
+git show --quiet
+
+sudo cp -v systemd/*.sh $MOUNT_POINT/ostree/deploy/rhcos/var/usrlocal/bin/
+sudo chmod ugo+x $MOUNT_POINT/ostree/deploy/rhcos/var/usrlocal/bin/*.sh
+sudo cp -v systemd/*.service ${ROOT_FS}/etc/systemd/system
+
+sudo rm -f ${ROOT_FS}/etc/systemd/system/crc-no-tap.service
+
+# Mute ovs-configuration.service
+
+sudo mkdir ${ROOT_FS}/etc/systemd/system/ovs-configuration.service.d
+cat | sudo tee ${ROOT_FS}/etc/systemd/system/ovs-configuration.service.d/mute-console.conf <<EOF
+[Service]
+StandardOutput=file:/var/log/ovs-configure.log
+StandardError=file:/var/log/ovs-configure.log
+EOF
+
+cat | sudo tee ${ROOT_FS}/etc/sysconfig/crc-env <<EOF
+CRC_SELF_SUFFICIENT=1
+CRC_NETWORK_MODE_USER=0
+EOF
+
+# --- !!! END OF MODIFICATIONS !!! ---
+
+echo "--- Unmounting filesystem ---"
+sudo umount ${MOUNT_POINT}

--- a/projects/crc-timing/toolbox/crc_timing_refresh_image/vars/main/resources.yaml
+++ b/projects/crc-timing/toolbox/crc_timing_refresh_image/vars/main/resources.yaml
@@ -1,0 +1,2 @@
+---
+instance_script_template: templates/instance_script.sh.j2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a CRC image refresh command with configurable options (snapshot, AMI name, key, repo/branch, region, AZ, instance type, etc.). Automates provisioning, volume attach, script execution, snapshotting, AMI registration, and cleanup, returning the new AMI ID.

- Documentation
  - Added auto-generated documentation for the CRC image refresh command and updated the toolbox index. Includes parameter descriptions and defaults.

- Chores
  - Added default configurations, resources, and initial dependency metadata to support the image refresh workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->