### PR TITLE
[remote] toolbox: remote_build_image: tasks/main: improve the syntax

### DIFF
--- a/projects/remote/toolbox/remote_build_image/tasks/main.yaml
+++ b/projects/remote/toolbox/remote_build_image/tasks/main.yaml
@@ -33,7 +33,7 @@
       cd "{{ remote_build_image_base_directory }}";
       ./{{ remote_build_image_prepare_script }} \
         &> "{{ artifact_extra_logs_dir }}/artifacts/prepare.log"
-    when: remote_build_image_prepare_script | default('', true) | trim
+    when: remote_build_image_prepare_script != None
 
   - name: Build the image
     shell: |


### PR DESCRIPTION
was crashing with newer versions of Ansible ...